### PR TITLE
Do not populate filename while opening file

### DIFF
--- a/src/vdr_pi.cpp
+++ b/src/vdr_pi.cpp
@@ -260,15 +260,14 @@ void vdr_pi::OnToolbarToolCallback(int id)
             }
             else
             {
-                  wxString idir, ifile;
+                  wxString idir;
                   if(m_ifilename.Length()){
                     wxFileName fn(m_ifilename);
                     idir = fn.GetPath();
-                    ifile = fn.GetFullName();
                   }
 
                   wxString file;
-                  int response = PlatformFileSelectorDialog( GetOCPNCanvasWindow(), &file, _("Choose a file to Play"), idir, ifile, _T("*.*") );
+                  int response = PlatformFileSelectorDialog( GetOCPNCanvasWindow(), &file, _("Choose a file to Play"), idir, "", _T("*.*") );
 
                   if( response != wxID_OK )
                   {


### PR DESCRIPTION
The API function expects that with file name populated the intention is to save a file and creates the dialog suggesting a save operation causing confusion to the user. I don't see any real reason for populating the filename, so simply remedy the situation by not doing it. 