### PR TITLE
Enhanced VDR controls

### DIFF
--- a/Plugin.cmake
+++ b/Plugin.cmake
@@ -52,6 +52,8 @@ set(SRC
   src/icons.cpp
   src/vdr_pi.h
   src/vdr_pi.cpp
+  src/vdr_pi_prefs.h
+  src/vdr_pi_prefs.cpp
 )
 
 

--- a/src/icons.sh
+++ b/src/icons.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/ bin / bash
 
 path=$(dirname $0)
 
-# Require icotool from package icoutils
-# Require convert from package ImageMagick
-# Require inkscape
+#Require icotool from package icoutils
+#Require convert from package ImageMagick
+#Require inkscape
 
 # 32x32
 for pic in $path/vdr_pi.svg $path/vdr_record.svg $path/vdr_play.svg
@@ -14,10 +14,13 @@ do
 done
 
 # 20x20
-#for pic in 
+#for pic in
 #do
-#  echo "converting $pic"
-#  inkscape --without-gui --export-png=$path/$(basename $pic .svg ).png --export-dpi=72 --export-background-opacity=0 --export-width=20 --export-height=20 $pic >/dev/null
+#echo "converting $pic"
+#inkscape-- without - gui-- export - png =            \
+    $path / $(basename $pic.svg).png-- export - dpi = \
+        72 --export - background - opacity =          \
+            0 --export - width = 20 --export - height = 20 $pic> / dev / null
 #done
 
 $path/../../../src/bitmaps/png2wx.pl -C $path/icons.cpp -H $path/icons.h -M ICONS_H $path/*.png

--- a/src/vdr_pi.cpp
+++ b/src/vdr_pi.cpp
@@ -32,17 +32,21 @@
 #include "wx/wx.h"
 #endif  // precompiled headers
 
+#include "wx/tokenzr.h"
+#include "wx/statline.h"
+
 #include <typeinfo>
+#include "vdr_pi_prefs.h"
 #include "vdr_pi.h"
 #include "icons.h"
 
 // the class factories, used to create and destroy instances of the PlugIn
 
-extern "C" DECL_EXP opencpn_plugin *create_pi(void *ppimgr) {
+extern "C" DECL_EXP opencpn_plugin* create_pi(void* ppimgr) {
   return new vdr_pi(ppimgr);
 }
 
-extern "C" DECL_EXP void destroy_pi(opencpn_plugin *p) { delete p; }
+extern "C" DECL_EXP void destroy_pi(opencpn_plugin* p) { delete p; }
 
 //---------------------------------------------------------------------------------------------------------
 //
@@ -50,7 +54,7 @@ extern "C" DECL_EXP void destroy_pi(opencpn_plugin *p) { delete p; }
 //
 //---------------------------------------------------------------------------------------------------------
 
-vdr_pi::vdr_pi(void *ppimgr) : opencpn_plugin_117(ppimgr), wxTimer(this) {
+vdr_pi::vdr_pi(void* ppimgr) : opencpn_plugin_117(ppimgr), wxTimer(this) {
   // Create the PlugIn icons
   initialize_images();
 
@@ -75,17 +79,26 @@ vdr_pi::vdr_pi(void *ppimgr) : opencpn_plugin_117(ppimgr), wxTimer(this) {
     m_panelBitmap = wxBitmap(panelIcon);
   else
     wxLogWarning("VDR panel icon has NOT been loaded");
+
+  m_pvdrcontrol = NULL;
+  m_recording = false;
+  m_data_format = VDRDataFormat::RawNMEA;
+  m_interval = 1000;  // Default 1 second interval
+  m_log_rotate = false;
+  m_log_rotate_interval = 24;
+  m_is_csv_file = false;
+  m_timestamp_idx = -1;
+  m_message_idx = -1;
 }
 
 int vdr_pi::Init(void) {
   AddLocaleCatalog(_T("opencpn-vdr_pi"));
 
-  //    Get a pointer to the opencpn configuration object
+  // Get a pointer to the opencpn configuration object
   m_pconfig = GetOCPNConfigObject();
   m_pauimgr = GetFrameAuiManager();
-  m_pvdrcontrol = NULL;
 
-  //    And load the configuration items
+  // Load the configuration items
   LoadConfig();
 
 #ifdef VDR_USE_SVG
@@ -108,7 +121,7 @@ int vdr_pi::Init(void) {
 #endif
 
   return (WANTS_TOOLBAR_CALLBACK | INSTALLS_TOOLBAR_TOOL | WANTS_CONFIG |
-          WANTS_NMEA_SENTENCES | WANTS_AIS_SENTENCES);
+          WANTS_NMEA_SENTENCES | WANTS_AIS_SENTENCES | WANTS_PREFERENCES);
 }
 
 bool vdr_pi::DeInit(void) {
@@ -129,6 +142,10 @@ bool vdr_pi::DeInit(void) {
   if (m_recording) {
     m_ostream.Close();
     m_recording = false;
+#ifdef __ANDROID__
+    AndroidSecureCopyFile(m_temp_outfile, m_final_outfile);
+    ::wxRemoveFile(m_temp_outfile);
+#endif
   }
 
   RemovePlugInTool(m_tb_item_id_record);
@@ -152,11 +169,11 @@ int GetPlugInVersionPatch() { return PLUGIN_VERSION_PATCH; }
 
 int GetPlugInVersionPost() { return PLUGIN_VERSION_TWEAK; }
 
-const char *GetPlugInVersionPre() { return PKG_PRERELEASE; }
+const char* GetPlugInVersionPre() { return PKG_PRERELEASE; }
 
-const char *GetPlugInVersionBuild() { return PKG_BUILD_INFO; }
+const char* GetPlugInVersionBuild() { return PKG_BUILD_INFO; }
 
-wxBitmap *vdr_pi::GetPlugInBitmap() { return &m_panelBitmap; }
+wxBitmap* vdr_pi::GetPlugInBitmap() { return &m_panelBitmap; }
 
 wxString vdr_pi::GetCommonName() { return _("VDR"); }
 
@@ -170,26 +187,240 @@ wxString vdr_pi::GetLongDescription() {
 Provides NMEA stream save and replay.");
 }
 
-void vdr_pi::SetNMEASentence(wxString &sentence) {
-  if (m_recording) m_ostream.Write(sentence);
+// Format timestamp: YYYY-MM-DDTHH:MM:SS.mmmZ
+// The format combines ISO format with milliseconds in UTC.
+wxString FormatIsoDateTime(const wxDateTime& ts) {
+  wxDateTime ts1 = ts.ToUTC();
+  wxString timestamp = ts1.Format("%Y-%m-%dT%H:%M:%S.");
+  timestamp += wxString::Format("%03ldZ", ts1.GetMillisecond());
+  return timestamp;
 }
 
-void vdr_pi::SetAISSentence(wxString &sentence) {
-  if (m_recording) m_ostream.Write(sentence);
+wxString vdr_pi::FormatNMEAAsCSV(const wxString& nmea) {
+  // Get current time with millisecond precision
+  wxString timestamp = FormatIsoDateTime(wxDateTime::UNow());
+
+  wxString type = "NMEA0183";
+  if (nmea.StartsWith("!")) {
+    type = "AIS";
+  }
+
+  // Escape any commas in the NMEA message
+  wxString escaped = nmea.Strip(wxString::both);
+  escaped.Replace("\"", "\"\"");
+  escaped = wxString::Format("\"%s\"", escaped);
+
+  return wxString::Format("%s,%s,%s\n", timestamp, type, escaped);
+}
+
+void vdr_pi::SetNMEASentence(wxString& sentence) {
+  if (!m_recording) return;
+
+  // Check if we need to rotate the VDR file.
+  CheckLogRotation();
+
+  switch (m_data_format) {
+    case VDRDataFormat::CSV:
+      m_ostream.Write(FormatNMEAAsCSV(sentence));
+      break;
+    case VDRDataFormat::RawNMEA:
+    default:
+      m_ostream.Write(sentence);
+      break;
+  }
+}
+
+void vdr_pi::SetAISSentence(wxString& sentence) {
+  SetNMEASentence(sentence);  // Handle the same way as NMEA
+}
+
+bool vdr_pi::IsNMEAOrAIS(const wxString& line) {
+  // NMEA sentences start with $ or !
+  return line.StartsWith("$") || line.StartsWith("!");
+}
+
+bool vdr_pi::ParseCSVHeader(const wxString& header) {
+  // Reset indices
+  m_timestamp_idx = -1;
+  m_message_idx = -1;
+  m_header_fields.Clear();
+
+  // If it looks like NMEA/AIS, it's not a header
+  if (IsNMEAOrAIS(header)) {
+    m_is_csv_file = false;
+    return false;
+  }
+
+  // Split the header line
+  wxStringTokenizer tokens(header, ",");
+  int idx = 0;
+
+  while (tokens.HasMoreTokens()) {
+    wxString field = tokens.GetNextToken().Trim(true).Trim(false).Lower();
+    m_header_fields.Add(field);
+
+    // Look for key fields
+    if (field.Contains("timestamp")) {
+      m_timestamp_idx = idx;
+    } else if (field.Contains("message")) {
+      m_message_idx = idx;
+    }
+    idx++;
+  }
+
+  // We need at least a message field to be valid
+  m_is_csv_file = (m_message_idx >= 0);
+
+  return m_is_csv_file;
+}
+
+/**
+ * Parse a timestamp from a string in ISO 8601 format.
+ */
+bool ParseTimestamp(const wxString& timeStr, wxDateTime* timestamp) {
+  wxString::const_iterator end;
+  wxDateTime tempTime;
+
+  // Try formats with milliseconds
+  if (tempTime.ParseFormat(timeStr, "%Y-%m-%dT%H:%M:%S.%l%z", &end)) {
+    *timestamp = tempTime;
+    return true;
+  }
+
+  // Try formats without milliseconds
+  if (tempTime.ParseFormat(timeStr, "%Y-%m-%dT%H:%M:%S%z", &end)) {
+    *timestamp = tempTime;
+    return true;
+  }
+
+  return false;
+}
+
+wxString vdr_pi::ParseCSVLine(const wxString& line, wxDateTime* timestamp) {
+  if (!m_is_csv_file || IsNMEAOrAIS(line)) return line;
+
+  wxArrayString fields;
+  wxString currentField;
+  bool inQuotes = false;
+
+  for (size_t i = 0; i < line.Length(); i++) {
+    wxChar ch = line[i];
+
+    if (ch == '"') {
+      if (inQuotes && i + 1 < line.Length() && line[i + 1] == '"') {
+        // Double quotes inside quoted field = escaped quote
+        currentField += '"';
+        i++;  // Skip next quote
+      } else {
+        // Toggle quote state
+        inQuotes = !inQuotes;
+      }
+    } else if (ch == ',' && !inQuotes) {
+      // End of field
+      fields.Add(currentField);
+      currentField.Clear();
+    } else {
+      currentField += ch;
+    }
+  }
+
+  // Add the last field
+  fields.Add(currentField);
+
+  // Parse timestamp if requested and available
+  if (timestamp && m_timestamp_idx >= 0 &&
+      m_timestamp_idx < fields.GetCount()) {
+    if (!ParseTimestamp(fields[m_timestamp_idx], timestamp)) {
+      return wxEmptyString;
+    }
+  }
+
+  // Get message field
+  if (m_message_idx >= fields.GetCount()) return wxEmptyString;
+
+  // No need to unescape quotes here as we handled them during parsing
+  return fields[m_message_idx];
 }
 
 void vdr_pi::Notify() {
+  if (!m_istream.IsOpened()) return;
+
   wxString str;
   int pos = m_istream.GetCurrentLine();
 
-  if (m_istream.Eof() || pos == -1)
+  if (m_istream.Eof() || pos == -1) {
+    // First line - check if it's CSV.
     str = m_istream.GetFirstLine();
-  else
+    if (ParseCSVHeader(str)) {
+      // It's CSV, get first data line.
+      str = m_istream.GetNextLine();
+      m_playback_base_time = m_firstTimestamp;
+    }
+  } else {
     str = m_istream.GetNextLine();
+  }
 
-  PushNMEABuffer(str + _T("\r\n"));
+  if (m_istream.Eof() && str.IsEmpty()) {
+    m_atFileEnd = true;
+    PausePlayback();
+    if (m_pvdrcontrol) {
+      m_pvdrcontrol->UpdateControls();
+    }
+    return;
+  }
 
-  if (m_pvdrcontrol) m_pvdrcontrol->SetProgress(pos);
+  // Parse the line according to detected format (CVS or raw NMEA/AIS)
+  if (m_is_csv_file) {
+    wxDateTime timestamp;
+    wxString nmea = ParseCSVLine(str, &timestamp);
+    if (!nmea.IsEmpty()) {
+      m_currentTimestamp = timestamp;
+      ScheduleNextPlayback();
+      PushNMEABuffer(nmea + _T("\r\n"));
+    }
+    if (m_pvdrcontrol) {
+      m_pvdrcontrol->SetProgress(GetProgressFraction());
+    }
+  } else {
+    // Raw NMEA/AIS sentences.
+    wxString nmea = ParseCSVLine(str, NULL);
+    if (!nmea.IsEmpty()) {
+      PushNMEABuffer(nmea + _T("\r\n"));
+    }
+    if (m_pvdrcontrol) {
+      double progress = static_cast<double>(pos) / m_istream.GetLineCount();
+      m_pvdrcontrol->SetProgress(progress);
+    }
+  }
+}
+
+void vdr_pi::ScheduleNextPlayback() {
+  double speedMultiplier = 1.0;
+  if (m_pvdrcontrol) {
+    speedMultiplier = m_pvdrcontrol->GetSpeedMultiplier();
+  }
+  // Calculate when this message should be played relative to playback start
+  wxTimeSpan elapsedTime = m_currentTimestamp - m_firstTimestamp;
+  wxLongLong ms = elapsedTime.GetMilliseconds();
+  double scaledMs = ms.ToDouble() / speedMultiplier;
+  wxTimeSpan scaledElapsed =
+      wxTimeSpan::Milliseconds(static_cast<long>(scaledMs));
+  wxDateTime targetTime = m_playback_base_time + scaledElapsed;
+
+  // Calculate how long to wait
+  wxDateTime now = wxDateTime::UNow();
+  wxLogMessage("Base time: %s, Target time: %s, Now: %s. scaledMs: %f",
+               m_playback_base_time.FormatISOCombined(),
+               targetTime.FormatISOCombined(), now.FormatISOCombined(),
+               scaledMs);
+  if (targetTime > now) {
+    wxTimeSpan waitTime = targetTime - now;
+    Start(static_cast<int>(waitTime.GetMilliseconds().ToDouble()),
+          wxTIMER_ONE_SHOT);
+  } else {
+    // We're behind schedule, play immediately
+    Start(1, wxTIMER_ONE_SHOT);
+  }
 }
 
 void vdr_pi::SetInterval(int interval) {
@@ -202,112 +433,70 @@ int vdr_pi::GetToolbarToolCount(void) { return 2; }
 
 void vdr_pi::OnToolbarToolCallback(int id) {
   if (id == m_tb_item_id_play) {
-    if (IsRunning())  // Timer started?
-    {
-      Stop();  // Stop timer
-      m_istream.Close();
-
-      if (m_pvdrcontrol) {
-        m_pauimgr->DetachPane(m_pvdrcontrol);
-        m_pvdrcontrol->Close();
-        m_pvdrcontrol->Destroy();
-        m_pvdrcontrol = NULL;
-      }
-      SetToolbarItemState(id, false);
-    } else {
-      wxString idir;
-      if (m_ifilename.Length()) {
-        wxFileName fn(m_ifilename);
-        idir = fn.GetPath();
-      }
-
-      wxString file;
-      int response = PlatformFileSelectorDialog(GetOCPNCanvasWindow(), &file,
-                                                _("Choose a file to Play"),
-                                                idir, "", _T("*.*"));
-
-      if (response != wxID_OK) {
-        SetToolbarItemState(id, false);
-        return;
-      }
-      m_ifilename.Clear();
-      m_ifilename = file;
-
-      m_istream.Open(m_ifilename);
-      Start(m_interval, wxTIMER_CONTINUOUS);  // start timer
-
-      if (!m_pvdrcontrol) {
-        m_pvdrcontrol =
-            new VDRControl(GetOCPNCanvasWindow(), wxID_ANY, this,
-                           1000 / m_interval, m_istream.GetLineCount());
-        wxAuiPaneInfo pane =
-            wxAuiPaneInfo()
-                .Name(_T("VDR"))
-                .Caption(wxString::Format(_("VDR replay: %s"), m_ifilename))
-                .CaptionVisible(true)
-                .Float()
-                .FloatingPosition(100, 100)
-                .Dockable(false)
-                .Fixed()
-                .CloseButton(false)
-                .Show(true);
-        m_pauimgr->AddPane(m_pvdrcontrol, pane);
-        m_pauimgr->Update();
-      }
-
-      SetToolbarItemState(id, true);
-    }
-  } else if (id == m_tb_item_id_record) {
+    // Don't allow playback while recording
     if (m_recording) {
-      m_ostream.Close();
-      m_recording = false;
-
+      wxMessageBox(_("Stop recording before starting playback."),
+                   _("VDR Plugin"), wxOK | wxICON_INFORMATION);
       SetToolbarItemState(id, false);
-#ifdef __ANDROID__
-      bool AndroidSecureCopyFile(wxString in, wxString out);
-      AndroidSecureCopyFile(m_temp_outfile, m_final_outfile);
-      ::wxRemoveFile(m_temp_outfile);
-#endif
+      return;
+    }
+    // Check if the toolbar button is being toggled off
+    if (m_pvdrcontrol) {
+      // Stop any active playback
+      if (IsRunning()) {
+        Stop();
+        m_istream.Close();
+      }
+
+      // Close and destroy the control window
+      m_pauimgr->DetachPane(m_pvdrcontrol);
+      m_pvdrcontrol->Close();
+      m_pvdrcontrol->Destroy();
+      m_pvdrcontrol = NULL;
+
+      // Update toolbar state
+      SetToolbarItemState(id, false);
+      return;
+    }
+
+    if (!m_pvdrcontrol) {
+      m_pvdrcontrol = new VDRControl(GetOCPNCanvasWindow(), wxID_ANY, this);
+      wxAuiPaneInfo pane = wxAuiPaneInfo()
+                               .Name(_T("VDR"))
+                               .Caption(_("Voyage Data Recorder"))
+                               .CaptionVisible(true)
+                               .Float()
+                               .FloatingPosition(100, 100)
+                               .Dockable(false)
+                               .Fixed()
+                               .CloseButton(true)
+                               .Show(true);
+      m_pauimgr->AddPane(m_pvdrcontrol, pane);
+      m_pauimgr->Update();
     } else {
-      wxString idir, ifile;
-      if (m_ofilename.Length()) {
-        wxFileName fn(m_ifilename);
-        idir = fn.GetPath();
-        ifile = fn.GetFullName();
-      } else {
-        ifile = wxString(_T("vdr.txt"));
-        idir = *GetpPrivateApplicationDataLocation();
+      m_pauimgr->GetPane(m_pvdrcontrol)
+          .Show(!m_pauimgr->GetPane(m_pvdrcontrol).IsShown());
+      m_pauimgr->Update();
+    }
+    SetToolbarItemState(id, true);
+  } else if (id == m_tb_item_id_record) {
+    // Don't allow recording while playing
+    if (IsRunning()) {
+      wxMessageBox(_("Stop playback before starting recording."),
+                   _("VDR Plugin"), wxOK | wxICON_INFORMATION);
+      SetToolbarItemState(id, false);
+      return;
+    }
+    if (m_recording) {
+      StopRecording();
+      SetToolbarItemState(id, false);
+    } else {
+      StartRecording();
+      if (m_recording) {
+        // Only set button state if recording started
+        // successfully
+        SetToolbarItemState(id, true);
       }
-
-#ifdef __ANDROID__
-      wxString file_uniq = wxString("vdr-");
-      wxDateTime now = wxDateTime::Now();
-      wxString uniq = now.FormatISOCombined();
-      ifile = file_uniq + uniq + ".txt";
-      idir = "/storage/emulated/0/Android/Documents";
-
-      m_temp_outfile = *GetpPrivateApplicationDataLocation();
-      m_temp_outfile += wxString("/vdr_temp.txt");
-#endif
-      wxString file;
-      int response = PlatformFileSelectorDialog(GetOCPNCanvasWindow(), &file,
-                                                _("Create a file to Record"),
-                                                idir, ifile, _T("*.*"));
-
-      if (response != wxID_OK) {
-        SetToolbarItemState(id, false);
-        return;
-      }
-      m_ofilename.Clear();
-      m_ofilename = file;
-#ifdef __ANDROID__
-      m_final_outfile = file;
-      m_ofilename = m_temp_outfile;
-#endif
-      m_ostream.Open(m_ofilename, wxFile::write);
-      m_recording = true;
-
-      SetToolbarItemState(id, true);
     }
   }
 }
@@ -318,34 +507,336 @@ void vdr_pi::SetColorScheme(PI_ColorScheme cs) {
   }
 }
 
+wxString vdr_pi::GenerateFilename() const {
+  wxDateTime now = wxDateTime::Now().ToUTC();
+  wxString timestamp = now.Format("%Y%m%dT%H%M%SZ");
+  wxString extension = (m_data_format == VDRDataFormat::CSV) ? ".csv" : ".txt";
+  return "vdr_" + timestamp + extension;
+}
+
 bool vdr_pi::LoadConfig(void) {
-  wxFileConfig *pConf = (wxFileConfig *)m_pconfig;
+  wxFileConfig* pConf = (wxFileConfig*)m_pconfig;
 
-  if (pConf) {
-    pConf->SetPath(_T("/PlugIns/VDR"));
+  if (!pConf) return false;
 
-    pConf->Read(_T("InputFilename"), &m_ifilename, wxEmptyString);
-    pConf->Read(_T("OutputFilename"), &m_ofilename, wxEmptyString);
-    pConf->Read(_T("Interval"), &m_interval, 1);
+  pConf->SetPath(_T("/PlugIns/VDR"));
+  pConf->Read(_T("InputFilename"), &m_ifilename, wxEmptyString);
+  pConf->Read(_T("OutputFilename"), &m_ofilename, wxEmptyString);
 
-    return true;
-  } else
-    return false;
+  // Default directory handling based on platform
+#ifdef __ANDROID__
+  wxString defaultDir =
+      "/storage/emulated/0/Android/data/org.opencpn.opencpn/files";
+#else
+  wxString defaultDir = *GetpPrivateApplicationDataLocation();
+#endif
+
+  pConf->Read(_T("RecordingDirectory"), &m_recording_dir, defaultDir);
+  pConf->Read(_T("Interval"), &m_interval, 1000);
+  pConf->Read(_T("LogRotate"), &m_log_rotate, false);
+  pConf->Read(_T("LogRotateInterval"), &m_log_rotate_interval, 24);
+
+  int format;
+  pConf->Read(_T("DataFormat"), &format,
+              static_cast<int>(VDRDataFormat::RawNMEA));
+  m_data_format = static_cast<VDRDataFormat>(format);
+
+  return true;
 }
 
 bool vdr_pi::SaveConfig(void) {
-  wxFileConfig *pConf = (wxFileConfig *)m_pconfig;
+  wxFileConfig* pConf = (wxFileConfig*)m_pconfig;
 
-  if (pConf) {
-    pConf->SetPath(_T("/PlugIns/VDR"));
+  if (!pConf) return false;
 
-    pConf->Write(_T("InputFilename"), m_ifilename);
-    pConf->Write(_T("OutputFilename"), m_ofilename);
-    pConf->Write(_T("Interval"), m_interval);
+  pConf->SetPath(_T("/PlugIns/VDR"));
+  pConf->Write(_T("InputFilename"), m_ifilename);
+  pConf->Write(_T("OutputFilename"), m_ofilename);
+  pConf->Write(_T("RecordingDirectory"), m_recording_dir);
+  pConf->Write(_T("Interval"), m_interval);
+  pConf->Write(_T("LogRotate"), m_log_rotate);
+  pConf->Write(_T("LogRotateInterval"), m_log_rotate_interval);
+  pConf->Write(_T("DataFormat"), static_cast<int>(m_data_format));
 
-    return true;
-  } else
+  return true;
+}
+
+void vdr_pi::StartRecording() {
+  if (m_recording) return;
+
+  // Generate filename based on current date/time
+  wxString filename = GenerateFilename();
+  wxString fullpath = wxFileName(m_recording_dir, filename).GetFullPath();
+
+#ifdef __ANDROID__
+  // For Android, we need to use the temp file for writing, but keep track of
+  // the final location
+  m_temp_outfile = *GetpPrivateApplicationDataLocation();
+  m_temp_outfile += wxString("/vdr_temp") +
+                    (m_data_format == VDRDataFormat::CSV ? ".csv" : ".txt");
+  m_final_outfile = "/storage/emulated/0/Android/Documents/" + filename;
+  fullpath = m_temp_outfile;
+#endif
+
+  // Ensure directory exists
+  if (!wxDirExists(m_recording_dir)) {
+    if (!wxMkdir(m_recording_dir)) {
+      wxLogError(_("Failed to create recording directory: %s"),
+                 m_recording_dir);
+      return;
+    }
+  }
+
+  if (!m_ostream.Open(fullpath, wxFile::write)) {
+    wxLogError(_("Failed to create recording file: %s"), fullpath);
+    return;
+  }
+
+  // Write CSV header if needed
+  if (m_data_format == VDRDataFormat::CSV) {
+    m_ostream.Write("timestamp,type,message\n");
+  }
+
+  m_recording = true;
+}
+
+void vdr_pi::StopRecording() {
+  if (!m_recording) return;
+
+  m_ostream.Close();
+  m_recording = false;
+
+#ifdef __ANDROID__
+  AndroidSecureCopyFile(m_temp_outfile, m_final_outfile);
+  ::wxRemoveFile(m_temp_outfile);
+#endif
+}
+
+void vdr_pi::AdjustPlaybackBaseTime() {
+  if (!m_firstTimestamp.IsValid() || !m_currentTimestamp.IsValid()) {
+    return;
+  }
+
+  // Get current speed multiplier from control
+  double speedMultiplier = 1.0;
+  if (m_pvdrcontrol) {
+    speedMultiplier = m_pvdrcontrol->GetSpeedMultiplier();
+  }
+
+  // Calculate how much time has "elapsed" in the recording up to our current
+  // position
+  wxTimeSpan elapsed = m_currentTimestamp - m_firstTimestamp;
+
+  // Set base time so that current playback position corresponds to current wall
+  // clock
+  m_playback_base_time =
+      wxDateTime::UNow() -
+      wxTimeSpan::Milliseconds(static_cast<long>(
+          (elapsed.GetMilliseconds().ToDouble() / speedMultiplier)));
+}
+
+void vdr_pi::StartPlayback() {
+  if (m_ifilename.IsEmpty()) {
+    wxMessageBox(_("No file selected."), _("VDR Plugin"),
+                 wxOK | wxICON_INFORMATION);
+    return;
+  }
+  if (!wxFileExists(m_ifilename)) {
+    wxMessageBox(_("File does not exist."), _("VDR Plugin"),
+                 wxOK | wxICON_INFORMATION);
+    return;
+  }
+
+  // Reset end-of-file state when starting playback
+  m_atFileEnd = false;
+
+  AdjustPlaybackBaseTime();
+
+  if (!m_istream.Open(m_ifilename)) {
+    wxMessageBox(_("Failed to open file."), _("VDR Plugin"),
+                 wxOK | wxICON_INFORMATION);
+    return;
+  }
+  Start(m_interval, wxTIMER_CONTINUOUS);
+  m_playing = true;
+
+  if (m_pvdrcontrol) {
+    m_pvdrcontrol->SetProgress(0);
+    m_pvdrcontrol->UpdateControls();
+    m_pvdrcontrol->UpdateFileLabel(m_ifilename);
+  }
+}
+
+void vdr_pi::PausePlayback() {
+  if (!m_playing) return;
+
+  Stop();
+  m_playing = false;
+  if (m_pvdrcontrol) m_pvdrcontrol->UpdateControls();
+}
+
+void vdr_pi::StopPlayback() {
+  if (!m_playing) return;
+
+  Stop();
+  m_playing = false;
+  m_istream.Close();
+
+  if (m_pvdrcontrol) {
+    m_pvdrcontrol->SetProgress(0);
+    m_pvdrcontrol->UpdateControls();
+    m_pvdrcontrol->UpdateFileLabel(wxEmptyString);
+  }
+}
+
+void vdr_pi::ShowPreferencesDialog(wxWindow* parent) {
+  VDRPrefsDialog dlg(parent, wxID_ANY, m_data_format, m_recording_dir,
+                     m_log_rotate, m_log_rotate_interval);
+  if (dlg.ShowModal() == wxID_OK) {
+    SetDataFormat(dlg.GetDataFormat());
+    SetRecordingDir(dlg.GetRecordingDir());
+    SaveConfig();
+
+    // Update UI if needed
+    if (m_pvdrcontrol) {
+      m_pvdrcontrol->UpdateControls();
+    }
+  }
+}
+
+void vdr_pi::CheckLogRotation() {
+  if (!m_recording || !m_log_rotate) return;
+
+  wxDateTime now = wxDateTime::Now().ToUTC();
+  wxTimeSpan elapsed = now - m_recording_start;
+
+  if (elapsed.GetHours() >= m_log_rotate_interval) {
+    // Stop current recording
+    StopRecording();
+    // Start new recording
+    StartRecording();
+  }
+}
+
+bool vdr_pi::ScanFileTimestamps() {
+  if (!m_istream.IsOpened() || !m_is_csv_file) {
     return false;
+  }
+
+  // Initialize timestamps as invalid
+  m_firstTimestamp = wxDateTime();  // Creates an invalid datetime
+  m_lastTimestamp = wxDateTime();   // Creates an invalid datetime
+
+  wxString line;
+  bool foundFirst = false;
+
+  // Read first non-header line for first timestamp
+  line = m_istream.GetFirstLine();
+  if (ParseCSVHeader(line)) {
+    line = m_istream.GetNextLine();
+  }
+
+  wxDateTime timestamp;
+  wxString nmea;
+  if (!line.IsEmpty()) {
+    nmea = ParseCSVLine(line, &timestamp);
+    if (!nmea.IsEmpty() && timestamp.IsValid()) {
+      m_firstTimestamp = timestamp;
+      foundFirst = true;
+      // Set initial timestamp to first timestamp if valid.
+      m_currentTimestamp = m_firstTimestamp;
+    }
+  }
+
+  // Scan to end of file for last timestamp
+  while (!m_istream.Eof()) {
+    line = m_istream.GetNextLine();
+    if (!line.IsEmpty()) {
+      nmea = ParseCSVLine(line, &timestamp);
+      if (!nmea.IsEmpty() && timestamp.IsValid()) {
+        m_lastTimestamp = timestamp;
+      }
+    }
+  }
+
+  // Reset file position
+  m_istream.GoToLine(0);
+  wxLogMessage("VDR file. First timestamp: %s. Last timestamp: %s",
+               FormatIsoDateTime(m_firstTimestamp),
+               FormatIsoDateTime(m_lastTimestamp));
+  return foundFirst && m_lastTimestamp.IsValid();
+}
+
+bool vdr_pi::SeekToFraction(double fraction) {
+  if (!m_istream.IsOpened() || !m_is_csv_file) {
+    return false;
+  }
+
+  // Calculate target timestamp
+  wxTimeSpan totalSpan = m_lastTimestamp - m_firstTimestamp;
+  wxTimeSpan targetSpan =
+      wxTimeSpan::Seconds((totalSpan.GetSeconds().ToDouble() * fraction));
+  wxDateTime targetTime = m_firstTimestamp + targetSpan;
+
+  // Scan file until we find first message after target time
+  m_istream.GoToLine(0);
+  wxString line = m_istream.GetFirstLine();
+  if (ParseCSVHeader(line)) {
+    line = m_istream.GetNextLine();
+  }
+
+  while (!m_istream.Eof()) {
+    wxDateTime timestamp;
+    wxString nmea = ParseCSVLine(line, &timestamp);
+    if (!nmea.IsEmpty() && timestamp.IsValid() && timestamp >= targetTime) {
+      // Found our position, prepare to play from here
+      m_currentTimestamp = timestamp;
+      // If we're currently playing, adjust the base time
+      if (m_playing) {
+        AdjustPlaybackBaseTime();
+      }
+      if (m_pvdrcontrol) {
+        m_pvdrcontrol->SetProgress(GetProgressFraction());
+      }
+      return true;
+    }
+    line = m_istream.GetNextLine();
+  }
+
+  return false;
+}
+
+double vdr_pi::GetProgressFraction() const {
+  if (!m_firstTimestamp.IsValid() || !m_lastTimestamp.IsValid() ||
+      !m_currentTimestamp.IsValid()) {
+    return 0.0;
+  }
+
+  wxTimeSpan totalSpan = m_lastTimestamp - m_firstTimestamp;
+  wxTimeSpan currentSpan = m_currentTimestamp - m_firstTimestamp;
+
+  if (totalSpan.GetSeconds().ToLong() == 0) {
+    return 0.0;
+  }
+
+  return currentSpan.GetSeconds().ToDouble() /
+         totalSpan.GetSeconds().ToDouble();
+}
+
+void vdr_pi::ClearInputFile() {
+  m_ifilename.Clear();
+  if (m_istream.IsOpened()) {
+    m_istream.Close();
+  }
+}
+
+wxString vdr_pi::GetInputFile() const {
+  if (!m_ifilename.IsEmpty()) {
+    if (wxFileExists(m_ifilename)) {
+      return m_ifilename;
+    }
+  }
+  return wxEmptyString;
 }
 
 //----------------------------------------------------------------
@@ -354,40 +845,323 @@ bool vdr_pi::SaveConfig(void) {
 //
 //----------------------------------------------------------------
 
-VDRControl::VDRControl(wxWindow *pparent, wxWindowID id, vdr_pi *vdr, int speed,
-                       int range)
-    : wxWindow(pparent, id, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE,
-               _T("Dashboard")),
-      m_pvdr(vdr) {
+enum {
+  ID_VDR_LOAD = wxID_HIGHEST + 1,
+  ID_VDR_PLAY_PAUSE,
+  ID_VDR_DATA_FORMAT_RADIOBUTTON,
+  ID_VDR_SPEED_SLIDER,
+  ID_VDR_PROGRESS
+};
+
+BEGIN_EVENT_TABLE(VDRControl, wxWindow)
+EVT_BUTTON(ID_VDR_LOAD, VDRControl::OnLoadButton)
+EVT_RADIOBUTTON(ID_VDR_DATA_FORMAT_RADIOBUTTON,
+                VDRControl::OnDataFormatRadioButton)
+EVT_BUTTON(ID_VDR_PLAY_PAUSE, VDRControl::OnPlayPauseButton)
+EVT_SLIDER(ID_VDR_SPEED_SLIDER, VDRControl::OnSpeedSliderUpdated)
+EVT_COMMAND_SCROLL_THUMBTRACK(ID_VDR_PROGRESS,
+                              VDRControl::OnProgressSliderUpdated)
+EVT_COMMAND_SCROLL_THUMBRELEASE(ID_VDR_PROGRESS,
+                                VDRControl::OnProgressSliderEndDrag)
+END_EVENT_TABLE()
+
+VDRControl::VDRControl(wxWindow* parent, wxWindowID id, vdr_pi* vdr)
+    : wxWindow(parent, id, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE,
+               _T("VDR Control")),
+      m_pvdr(vdr),
+      m_isDragging(false),
+      m_wasPlayingBeforeDrag(false) {
   wxColour cl;
   GetGlobalColor(_T("DILG1"), &cl);
   SetBackgroundColour(cl);
 
-  wxFlexGridSizer *topsizer = new wxFlexGridSizer(2);
-  topsizer->AddGrowableCol(1);
+  CreateControls();
 
-  wxStaticText *itemStaticText01 =
-      new wxStaticText(this, wxID_ANY, _("Speed:"));
-  topsizer->Add(itemStaticText01, 0, wxEXPAND | wxALL, 2);
+  // Check if there's already a file loaded from config
+  wxString currentFile = m_pvdr->GetInputFile();
+  if (!currentFile.IsEmpty()) {
+    // Try to load the file
+    if (m_pvdr->LoadFile(currentFile)) {
+      UpdateFileLabel(currentFile);
+      UpdateControls();
+    } else {
+      // If loading fails, clear the saved filename
+      m_pvdr->ClearInputFile();
+      UpdateFileLabel(wxEmptyString);
+      UpdateControls();
+    }
+  }
+}
 
-  m_pslider = new wxSlider(this, wxID_ANY, speed, 1, 100, wxDefaultPosition,
-                           wxSize(200, 20));
-  topsizer->Add(m_pslider, 1, wxALL | wxEXPAND, 2);
-  m_pslider->Connect(wxEVT_COMMAND_SLIDER_UPDATED,
-                     wxCommandEventHandler(VDRControl::OnSliderUpdated), NULL,
-                     this);
+void VDRControl::CreateControls() {
+  // Main vertical sizer
+  wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
 
-  wxStaticText *itemStaticText02 =
-      new wxStaticText(this, wxID_ANY, _("Progress:"));
-  topsizer->Add(itemStaticText02, 0, wxEXPAND | wxALL, 2);
+  // File information section
+  wxStaticBox* fileBox = new wxStaticBox(this, wxID_ANY, _("VDR File"));
+  wxStaticBoxSizer* fileSizer = new wxStaticBoxSizer(fileBox, wxVERTICAL);
+  m_loadBtn = new wxButton(this, ID_VDR_LOAD, _("Load"));
+  fileSizer->Add(m_loadBtn, 0, wxALL | wxALIGN_CENTER, 5);
+  m_fileLabel =
+      new wxStaticText(this, wxID_ANY, _("No file loaded"), wxDefaultPosition,
+                       wxDefaultSize, wxST_ELLIPSIZE_START);
+  fileSizer->Add(m_fileLabel, 1, wxEXPAND | wxALL, 5);
+  mainSizer->Add(fileSizer, 0, wxEXPAND | wxALL,
+                 5);  // Add fileSizer, not fileBox
 
-  m_pgauge = new wxGauge(this, wxID_ANY, range, wxDefaultPosition,
-                         wxDefaultSize, wxGA_HORIZONTAL);
-  topsizer->Add(m_pgauge, 1, wxALL | wxEXPAND, 2);
+  // Playback section
+  wxStaticBox* playBox = new wxStaticBox(this, wxID_ANY, _("Playback"));
+  wxStaticBoxSizer* playSizer = new wxStaticBoxSizer(playBox, wxVERTICAL);
 
-  SetSizer(topsizer);
-  topsizer->Fit(this);
+  m_playBtnTooltip = _("Start Playback");
+  m_pauseBtnTooltip = _("Pause Playback");
+  m_stopBtnTooltip = _("End of File");
+
+  m_playPauseBtn =
+      new wxButton(this, ID_VDR_PLAY_PAUSE, wxString::FromUTF8("▶"),
+                   wxDefaultPosition, wxDefaultSize, 0);
+  wxSize buttonSize(40, 40);
+  m_playPauseBtn->SetMinSize(buttonSize);
+  m_playPauseBtn->SetInitialSize(buttonSize);
+  wxFont font = m_playPauseBtn->GetFont();
+  font.SetPointSize(font.GetPointSize() * 1.5);
+  m_playPauseBtn->SetFont(font);
+  m_playPauseBtn->SetToolTip(m_playBtnTooltip);
+  playSizer->Add(m_playPauseBtn, 0, wxALL | wxALIGN_CENTER | wxSHAPED, 5);
+
+  // Speed control
+  wxBoxSizer* speedSizer = new wxBoxSizer(wxHORIZONTAL);
+  speedSizer->Add(new wxStaticText(this, wxID_ANY, _("Replay Speed:")), 0,
+                  wxALIGN_CENTER_VERTICAL | wxALL, 5);
+
+  m_speedSlider =
+      new wxSlider(this, wxID_ANY, 1, 1, 100, wxDefaultPosition, wxDefaultSize,
+                   wxSL_HORIZONTAL | wxSL_VALUE_LABEL);
+  speedSizer->Add(m_speedSlider, 1, wxEXPAND | wxALL, 5);
+  playSizer->Add(speedSizer, 0, wxEXPAND);
+
+  // Progress gauge
+  wxBoxSizer* timeSizer = new wxBoxSizer(wxVERTICAL);
+
+  m_timeLabel = new wxStaticText(this, wxID_ANY, _("Date and Time: --"));
+  timeSizer->Add(m_timeLabel, 0, wxALL | wxALIGN_LEFT, 5);
+
+  m_progressSlider =
+      new wxSlider(this, ID_VDR_PROGRESS, 0, 0, 1000, wxDefaultPosition,
+                   wxDefaultSize, wxSL_HORIZONTAL | wxSL_BOTTOM);
+  timeSizer->Add(m_progressSlider, 1, wxEXPAND | wxALL, 5);
+  playSizer->Add(timeSizer, 0, wxEXPAND);
+
+  mainSizer->Add(playSizer, 0, wxEXPAND | wxALL,
+                 5);  // Add playSizer, not playBox
+
+  SetSizer(mainSizer);
+  mainSizer->Fit(this);
   Layout();
+
+  // Initial state
+  UpdateControls();
+}
+
+void VDRControl::UpdateTimeLabel() {
+  if (m_pvdr->GetCurrentTimestamp().IsValid()) {
+    wxString timeStr =
+        m_pvdr->GetCurrentTimestamp().ToUTC().Format("%Y-%m-%d %H:%M:%S UTC");
+    m_timeLabel->SetLabel("Date and Time: " + timeStr);
+  } else {
+    m_timeLabel->SetLabel(_("Date and Time: --"));
+  }
+}
+
+void VDRControl::OnLoadButton(wxCommandEvent& event) {
+  // Stop any current playback
+  if (m_pvdr->IsPlaying()) {
+    m_pvdr->StopPlayback();
+  }
+
+  wxString file;
+  int response = PlatformFileSelectorDialog(GetOCPNCanvasWindow(), &file,
+                                            _("Select Playback File"),
+                                            wxEmptyString, _T(""), _T("*.*"));
+
+  if (response == wxID_OK) {
+    if (m_pvdr->LoadFile(file)) {  // We'll add this method to vdr_pi
+      UpdateFileLabel(file);
+      m_progressSlider->SetValue(0);
+      UpdateControls();
+    }
+  }
+}
+
+bool vdr_pi::LoadFile(const wxString& filename) {
+  if (IsPlaying()) {
+    StopPlayback();
+  }
+
+  m_ifilename = filename;
+  if (!m_istream.Open(m_ifilename)) {
+    wxMessageBox(_("Failed to open file: ") + filename, _("VDR Plugin"),
+                 wxOK | wxICON_ERROR);
+    return false;
+  }
+
+  // Reset file position
+  m_istream.GoToLine(0);
+  m_firstTimestamp = wxDateTime();    // Invalid datetime
+  m_lastTimestamp = wxDateTime();     // Invalid datetime
+  m_currentTimestamp = wxDateTime();  // Invalid datetime
+  m_atFileEnd = false;
+
+  // Scan timestamps if it's a CSV file.
+  wxString firstLine = m_istream.GetFirstLine();
+  if (ParseCSVHeader(firstLine)) {
+    if (!ScanFileTimestamps()) {
+      wxMessageBox(_("No valid timestamps found in file."), _("VDR Plugin"),
+                   wxOK | wxICON_ERROR);
+      m_istream.Close();
+      return false;
+    }
+    m_istream.GoToLine(0);
+  }
+
+  return true;
+}
+
+void VDRControl::OnProgressSliderUpdated(wxScrollEvent& event) {
+  if (!m_isDragging) {
+    m_isDragging = true;
+    m_wasPlayingBeforeDrag = m_pvdr->IsPlaying();
+    if (m_wasPlayingBeforeDrag) {
+      m_pvdr->PausePlayback();
+    }
+  }
+  if (m_pvdr->GetFirstTimestamp().IsValid() &&
+      m_pvdr->GetLastTimestamp().IsValid()) {
+    // Update time display while dragging but don't seek yet
+    double fraction = m_progressSlider->GetValue() / 1000.0;
+    wxTimeSpan totalSpan =
+        m_pvdr->GetLastTimestamp() - m_pvdr->GetFirstTimestamp();
+    wxTimeSpan currentSpan =
+        wxTimeSpan::Seconds((totalSpan.GetSeconds().ToDouble() * fraction));
+    m_pvdr->SetCurrentTimestamp(m_pvdr->GetFirstTimestamp() + currentSpan);
+    UpdateTimeLabel();
+  }
+  event.Skip();
+}
+
+void VDRControl::OnProgressSliderEndDrag(wxScrollEvent& event) {
+  double fraction = m_progressSlider->GetValue() / 1000.0;
+  m_pvdr->SeekToFraction(fraction);
+  if (m_wasPlayingBeforeDrag) {
+    m_pvdr->StartPlayback();
+  }
+  m_isDragging = false;
+  UpdateControls();
+  event.Skip();
+}
+
+void vdr_pi::SetToolbarToolStatus(int id, bool status) {
+  if (id == m_tb_item_id_play || id == m_tb_item_id_record) {
+    SetToolbarItemState(id, status);
+  }
+}
+
+void VDRControl::UpdateControls() {
+  bool hasFile = !m_pvdr->GetInputFile().IsEmpty();
+  bool isRecording = m_pvdr->IsRecording();
+  bool isPlaying = m_pvdr->IsPlaying();
+  bool isAtEnd = m_pvdr->IsAtFileEnd();
+
+  // Update the play/pause/stop button appearance
+  if (isAtEnd) {
+    m_playPauseBtn->SetLabel(wxString::FromUTF8("⏹"));
+    m_playPauseBtn->SetToolTip(m_stopBtnTooltip);
+  } else {
+    m_playPauseBtn->SetLabel(isPlaying ? wxString::FromUTF8("⏸")
+                                       : wxString::FromUTF8("▶"));
+    m_playPauseBtn->SetToolTip(isPlaying ? m_pauseBtnTooltip
+                                         : m_playBtnTooltip);
+  }
+
+  // Enable/disable controls based on state
+  m_loadBtn->Enable(!isRecording && !isPlaying);
+  m_playPauseBtn->Enable(hasFile && !isRecording);
+  m_progressSlider->Enable(hasFile && !isRecording);
+
+  // Update toolbar state
+  m_pvdr->SetToolbarToolStatus(m_pvdr->GetPlayToolbarItemId(), isPlaying);
+
+  // Update time display
+  if (hasFile && m_pvdr->GetCurrentTimestamp().IsValid()) {
+    wxString timeStr =
+        m_pvdr->GetCurrentTimestamp().ToUTC().Format("%Y-%m-%d %H:%M:%S UTC");
+    m_timeLabel->SetLabel("Date and Time: " + timeStr);
+  } else {
+    m_timeLabel->SetLabel(_("Date and Time: --"));
+  }
+
+  // Update layout
+  Layout();
+}
+
+void VDRControl::UpdateFileLabel(const wxString& filename) {
+  if (filename.IsEmpty()) {
+    m_fileLabel->SetLabel(_("No file loaded"));
+  } else {
+    wxFileName fn(filename);
+    m_fileLabel->SetLabel(fn.GetFullName());
+  }
+  m_fileLabel->GetParent()->Layout();
+}
+
+void VDRControl::OnPlayPauseButton(wxCommandEvent& event) {
+  if (!m_pvdr->IsPlaying()) {
+    if (m_pvdr->GetInputFile().IsEmpty()) {
+      wxMessageBox(_("Please load a file first."), _("VDR Plugin"),
+                   wxOK | wxICON_INFORMATION);
+      return;
+    }
+
+    // If we're at the end, restart from beginning
+    if (m_pvdr->IsAtFileEnd()) {
+      m_pvdr->StopPlayback();
+    }
+
+    m_pvdr->StartPlayback();
+  } else {
+    m_pvdr->PausePlayback();
+  }
+  UpdateControls();
+}
+
+void VDRControl::OnDataFormatRadioButton(wxCommandEvent& event) {
+  // Radio button state is tracked by wx, we just need to handle any
+  // format-specific UI updates here if needed in the future
+}
+
+void VDRControl::OnSpeedSliderUpdated(wxCommandEvent& event) {
+  if (m_pvdr->IsPlaying()) {
+    m_pvdr->AdjustPlaybackBaseTime();
+  }
+}
+
+void VDRControl::SetProgress(double fraction) {
+  if (m_pvdr->GetFirstTimestamp().IsValid() &&
+      m_pvdr->GetLastTimestamp().IsValid()) {
+    // Update slider position (0-1000 range)
+    int sliderPos = wxRound(fraction * 1000);
+    m_progressSlider->SetValue(sliderPos);
+
+    // Calculate and set current timestamp based on the fraction
+    wxTimeSpan totalSpan =
+        m_pvdr->GetLastTimestamp() - m_pvdr->GetFirstTimestamp();
+    wxTimeSpan currentSpan =
+        wxTimeSpan::Seconds((totalSpan.GetSeconds().ToDouble() * fraction));
+    m_pvdr->SetCurrentTimestamp(m_pvdr->GetFirstTimestamp() + currentSpan);
+
+    // Update time display
+    UpdateTimeLabel();
+  }
 }
 
 void VDRControl::SetColorScheme(PI_ColorScheme cs) {
@@ -396,10 +1170,4 @@ void VDRControl::SetColorScheme(PI_ColorScheme cs) {
   SetBackgroundColour(cl);
 
   Refresh(false);
-}
-
-void VDRControl::SetProgress(int progress) { m_pgauge->SetValue(progress); }
-
-void VDRControl::OnSliderUpdated(wxCommandEvent &event) {
-  m_pvdr->SetInterval(1000 / m_pslider->GetValue());
 }

--- a/src/vdr_pi.h
+++ b/src/vdr_pi.h
@@ -39,6 +39,7 @@
 #include <wx/filepicker.h>
 #include <wx/file.h>
 #include <wx/aui/aui.h>
+#include <wx/radiobut.h>
 #include "ocpn_plugin.h"
 #include "config.h"
 
@@ -50,9 +51,21 @@
 
 class VDRControl;
 
+enum class VDRDataFormat {
+  RawNMEA,  // Default raw NMEA format
+  CSV,      // CSV with timestamps
+            // Future formats can be added here
+};
+
+struct CSVField {
+  wxString name;
+  int index;
+  bool required;  // Is this field required for playback?
+};
+
 class vdr_pi : public opencpn_plugin_117, wxTimer {
 public:
-  vdr_pi(void *ppimgr);
+  vdr_pi(void* ppimgr);
 
   //    The required PlugIn Methods
   int Init(void);
@@ -62,7 +75,7 @@ public:
   int GetAPIVersionMinor();
   int GetPlugInVersionMajor();
   int GetPlugInVersionMinor();
-  wxBitmap *GetPlugInBitmap();
+  wxBitmap* GetPlugInBitmap();
   wxString GetCommonName();
   wxString GetShortDescription();
   wxString GetLongDescription();
@@ -71,46 +84,140 @@ public:
   void SetInterval(int interval);
 
   //    The optional method overrides
-  void SetNMEASentence(wxString &sentence);
-  void SetAISSentence(wxString &sentence);
+  void SetNMEASentence(wxString& sentence);
+  void SetAISSentence(wxString& sentence);
   int GetToolbarToolCount(void);
   void OnToolbarToolCallback(int id);
   void SetColorScheme(PI_ColorScheme cs);
 
+  bool LoadFile(const wxString& filename);
+  void StartRecording();
+  void StopRecording();
+  void StartPlayback();
+  void PausePlayback();
+  void StopPlayback();
+  bool IsRecording() { return m_recording; }
+  bool IsPlaying() { return m_playing; }
+  bool IsAtFileEnd() const { return m_atFileEnd; }
+  /**
+   * Schedule the next playback message based on the message timestamp.
+   */
+  void ScheduleNextPlayback();
+
+  void ShowPreferencesDialog(wxWindow* parent);
+  VDRDataFormat GetDataFormat() const { return m_data_format; }
+  void SetDataFormat(VDRDataFormat dataFormat) { m_data_format = dataFormat; };
+  wxString GetRecordingDir() const { return m_recording_dir; }
+  void SetRecordingDir(const wxString& dir) { m_recording_dir = dir; }
+  wxString GenerateFilename() const;
+
+  bool IsLogRotateEnabled() const { return m_log_rotate; }
+  void SetLogRotate(bool enable) { m_log_rotate = enable; }
+  int GetLogRotateInterval() const { return m_log_rotate_interval; }
+  void SetLogRotateInterval(int hours) { m_log_rotate_interval = hours; }
+  void CheckLogRotation();
+  void SetToolbarToolStatus(int id, bool status);
+  int GetPlayToolbarItemId() const { return m_tb_item_id_play; }
+
+  bool ScanFileTimestamps();
+  bool SeekToFraction(double fraction);
+  double GetProgressFraction() const;
+
+  wxDateTime GetFirstTimestamp() const { return m_firstTimestamp; }
+  wxDateTime GetLastTimestamp() const { return m_lastTimestamp; }
+  wxDateTime GetCurrentTimestamp() const { return m_currentTimestamp; }
+  void SetCurrentTimestamp(const wxDateTime& timestamp) {
+    m_currentTimestamp = timestamp;
+  }
+  wxString GetInputFile() const;
+  void ClearInputFile();
+  void AdjustPlaybackBaseTime();
+
 private:
   bool LoadConfig(void);
   bool SaveConfig(void);
+  wxString FormatNMEAAsCSV(const wxString& nmea);
+  bool ParseCSVHeader(const wxString& header);
+  wxString ParseCSVLine(const wxString& line, wxDateTime* timestamp);
+  bool IsNMEAOrAIS(const wxString& line);
 
   int m_tb_item_id_record;
   int m_tb_item_id_play;
 
-  wxFileConfig *m_pconfig;
-  wxAuiManager *m_pauimgr;
-  VDRControl *m_pvdrcontrol;
+  wxFileConfig* m_pconfig;
+  wxAuiManager* m_pauimgr;
+  VDRControl* m_pvdrcontrol;
   wxString m_ifilename;
   wxString m_ofilename;
+  wxString m_recording_dir;  // Directory where recordings are saved
   int m_interval;
   bool m_recording;
+  bool m_playing;
+  bool m_atFileEnd;
+
+  VDRDataFormat m_data_format;
   wxTextFile m_istream;
   wxFile m_ostream;
   wxBitmap m_panelBitmap;
+
+  bool m_is_csv_file;
+  wxArrayString m_header_fields;
+  int m_timestamp_idx;
+  int m_message_idx;
+
+  bool m_log_rotate;             // Whether to automatically rotate log files
+  int m_log_rotate_interval;     // Log rotation interval in hours
+  wxDateTime m_recording_start;  // When current recording started
+
+  wxDateTime m_playback_base_time;  // Real time when playback started
+
+  wxDateTime m_firstTimestamp;
+  wxDateTime m_lastTimestamp;
+  wxDateTime m_currentTimestamp;
+
+#ifdef __ANDROID__
   wxString m_temp_outfile;
   wxString m_final_outfile;
+#endif
 };
 
 class VDRControl : public wxWindow {
 public:
-  VDRControl(wxWindow *pparent, wxWindowID id, vdr_pi *vdr, int speed,
-             int range);
+  VDRControl(wxWindow* pparent, wxWindowID id, vdr_pi* vdr);
   void SetColorScheme(PI_ColorScheme cs);
-  void SetProgress(int progress);
+  void SetProgress(double fraction);
+  void UpdateControls();
+  void UpdateFileLabel(const wxString& filename);
+  void UpdateTimeLabel();
+  double GetSpeedMultiplier() const { return m_speedSlider->GetValue(); }
 
 private:
-  void OnSliderUpdated(wxCommandEvent &event);
+  void CreateControls();
+  void OnLoadButton(wxCommandEvent& event);
+  void OnPlayPauseButton(wxCommandEvent& event);
+  void OnSpeedSliderUpdated(wxCommandEvent& event);
 
-  vdr_pi *m_pvdr;
-  wxSlider *m_pslider;
-  wxGauge *m_pgauge;
+  void OnProgressSliderUpdated(wxScrollEvent& even);
+  void OnProgressSliderEndDrag(wxScrollEvent& event);
+
+  void OnDataFormatRadioButton(wxCommandEvent& event);
+
+  wxButton* m_loadBtn;
+  wxButton* m_playPauseBtn;
+  wxString m_playBtnTooltip;
+  wxString m_pauseBtnTooltip;
+  wxString m_stopBtnTooltip;
+
+  wxSlider* m_speedSlider;
+  wxSlider* m_progressSlider;
+  wxStaticText* m_fileLabel;
+  wxStaticText* m_timeLabel;
+  vdr_pi* m_pvdr;
+
+  bool m_isDragging;
+  bool m_wasPlayingBeforeDrag;
+
+  DECLARE_EVENT_TABLE()
 };
 
 #endif

--- a/src/vdr_pi_prefs.cpp
+++ b/src/vdr_pi_prefs.cpp
@@ -1,0 +1,148 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  VDR Plugin
+ *
+ ***************************************************************************
+ *   Copyright (C) 2024 by David S. Register                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ **************************************************************************/
+
+#include "vdr_pi_prefs.h"
+
+enum { ID_VDR_DIR_BUTTON = wxID_HIGHEST + 1, ID_VDR_LOG_ROTATE_CHECK };
+
+BEGIN_EVENT_TABLE(VDRPrefsDialog, wxDialog)
+EVT_BUTTON(wxID_OK, VDRPrefsDialog::OnOK)
+EVT_BUTTON(ID_VDR_DIR_BUTTON, VDRPrefsDialog::OnDirSelect)
+EVT_CHECKBOX(ID_VDR_LOG_ROTATE_CHECK, VDRPrefsDialog::OnLogRotateCheck)
+END_EVENT_TABLE()
+
+VDRPrefsDialog::VDRPrefsDialog(wxWindow* parent, wxWindowID id,
+                               VDRDataFormat format,
+                               const wxString& recordingDir, bool logRotate,
+                               int logRotateInterval)
+    : wxDialog(parent, id, _("VDR Preferences"), wxDefaultPosition,
+               wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+      m_format(format),
+      m_recording_dir(recordingDir),
+      m_log_rotate(logRotate),
+      m_log_rotate_interval(logRotateInterval) {
+  CreateControls();
+  GetSizer()->Fit(this);
+  GetSizer()->SetSizeHints(this);
+  Centre();
+}
+
+void VDRPrefsDialog::CreateControls() {
+  wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
+  SetSizer(mainSizer);
+
+  // Add format choice
+  wxStaticBox* formatBox =
+      new wxStaticBox(this, wxID_ANY, _("Recording Format"));
+  wxStaticBoxSizer* formatSizer = new wxStaticBoxSizer(formatBox, wxVERTICAL);
+
+  m_nmeaRadio = new wxRadioButton(this, wxID_ANY, _("Raw NMEA"),
+                                  wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+  m_csvRadio = new wxRadioButton(this, wxID_ANY, _("CSV with timestamps"));
+
+  formatSizer->Add(m_nmeaRadio, 0, wxALL, 5);
+  formatSizer->Add(m_csvRadio, 0, wxALL, 5);
+
+  mainSizer->Add(formatSizer, 0, wxEXPAND | wxALL, 5);
+
+  // Add recording directory controls
+  wxStaticBox* dirBox =
+      new wxStaticBox(this, wxID_ANY, _("Recording Directory"));
+  wxStaticBoxSizer* dirSizer = new wxStaticBoxSizer(dirBox, wxHORIZONTAL);
+
+  m_dirCtrl = new wxTextCtrl(this, wxID_ANY, m_recording_dir, wxDefaultPosition,
+                             wxDefaultSize, wxTE_READONLY);
+  m_dirButton = new wxButton(this, ID_VDR_DIR_BUTTON, _("Browse..."));
+
+  dirSizer->Add(m_dirCtrl, 1, wxALL | wxEXPAND, 5);
+  dirSizer->Add(m_dirButton, 0, wxALL | wxEXPAND, 5);
+
+  mainSizer->Add(dirSizer, 0, wxEXPAND | wxALL, 5);
+
+  // Select current format
+  switch (m_format) {
+    case VDRDataFormat::CSV:
+      m_csvRadio->SetValue(true);
+      break;
+    case VDRDataFormat::RawNMEA:
+    default:
+      m_nmeaRadio->SetValue(true);
+      break;
+  }
+
+  wxStaticBox* logBox =
+      new wxStaticBox(this, wxID_ANY, _("VDR File Management"));
+  wxStaticBoxSizer* logSizer = new wxStaticBoxSizer(logBox, wxVERTICAL);
+
+  m_logRotateCheck = new wxCheckBox(this, ID_VDR_LOG_ROTATE_CHECK,
+                                    _("Create new VDR file every:"));
+  m_logRotateCheck->SetValue(m_log_rotate);
+
+  wxBoxSizer* intervalSizer = new wxBoxSizer(wxHORIZONTAL);
+  m_logRotateIntervalCtrl = new wxSpinCtrl(
+      this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+      wxSP_ARROW_KEYS, 1, 168, m_log_rotate_interval);
+  intervalSizer->Add(m_logRotateIntervalCtrl, 0,
+                     wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+  intervalSizer->Add(new wxStaticText(this, wxID_ANY, _("hours")), 0,
+                     wxALIGN_CENTER_VERTICAL);
+
+  logSizer->Add(m_logRotateCheck, 0, wxALL, 5);
+  logSizer->Add(intervalSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM, 5);
+
+  mainSizer->Add(logSizer, 0, wxEXPAND | wxALL, 5);
+
+  // Enable/disable interval control based on checkbox
+  m_logRotateIntervalCtrl->Enable(m_log_rotate);
+
+  // Standard dialog buttons
+  wxStdDialogButtonSizer* buttonSizer = new wxStdDialogButtonSizer();
+  buttonSizer->AddButton(new wxButton(this, wxID_OK));
+  buttonSizer->AddButton(new wxButton(this, wxID_CANCEL));
+  buttonSizer->Realize();
+
+  mainSizer->Add(buttonSizer, 0, wxEXPAND | wxALL, 5);
+}
+
+void VDRPrefsDialog::OnOK(wxCommandEvent& event) {
+  m_format =
+      m_csvRadio->GetValue() ? VDRDataFormat::CSV : VDRDataFormat::RawNMEA;
+  m_log_rotate = m_logRotateCheck->GetValue();
+  m_log_rotate_interval = m_logRotateIntervalCtrl->GetValue();
+  event.Skip();
+}
+
+void VDRPrefsDialog::OnDirSelect(wxCommandEvent& event) {
+  wxDirDialog dlg(this, _("Choose a directory"), m_recording_dir,
+                  wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
+
+  if (dlg.ShowModal() == wxID_OK) {
+    m_recording_dir = dlg.GetPath();
+    m_dirCtrl->SetValue(m_recording_dir);
+  }
+}
+
+void VDRPrefsDialog::OnLogRotateCheck(wxCommandEvent& event) {
+  m_logRotateIntervalCtrl->Enable(event.IsChecked());
+}

--- a/src/vdr_pi_prefs.h
+++ b/src/vdr_pi_prefs.h
@@ -1,0 +1,69 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  VDR Plugin
+ *
+ ***************************************************************************
+ *   Copyright (C) 2024 by David S. Register                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ **************************************************************************/
+
+#ifndef _VDR_PI_PREFS_H_
+#define _VDR_PI_PREFS_H_
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
+#include <wx/dialog.h>
+#include <wx/spinctrl.h>
+
+#include "vdr_pi.h"
+
+class VDRPrefsDialog : public wxDialog {
+public:
+  VDRPrefsDialog(wxWindow* parent, wxWindowID id, VDRDataFormat format,
+                 const wxString& recordingDir, bool logRotate,
+                 int logRotateInterval);
+  VDRDataFormat GetDataFormat() const { return m_format; }
+  wxString GetRecordingDir() const { return m_recording_dir; }
+  bool GetLogRotate() const { return m_log_rotate; }
+  int GetLogRotateInterval() const { return m_log_rotate_interval; }
+
+private:
+  void OnOK(wxCommandEvent& event);
+  void OnDirSelect(wxCommandEvent& event);
+  void OnLogRotateCheck(wxCommandEvent& event);
+  void CreateControls();
+
+  wxRadioButton* m_nmeaRadio;
+  wxRadioButton* m_csvRadio;
+  wxTextCtrl* m_dirCtrl;
+  wxButton* m_dirButton;
+  wxCheckBox* m_logRotateCheck;
+  wxSpinCtrl* m_logRotateIntervalCtrl;
+
+  VDRDataFormat m_format;
+  wxString m_recording_dir;
+  bool m_log_rotate;
+  int m_log_rotate_interval;
+
+  DECLARE_EVENT_TABLE()
+};
+
+#endif


### PR DESCRIPTION
This is a draft PR to add more VDR controls:
1. Start/Pause
2. Speed control.
3. Plugin preferences:
   1. Output format of VDR data can be selected to raw NMEA (default) or CSV.
   2. Directory where to write VDR files.
   3. Option to log rotate files (disabled by default) every X hours.
4. File names are date/time in ISO8601 format, UTC. For example: `vdr_20241208T185219Z.csv`.
5. If input file is in CSV format, use timestamp to replay at the rate of the timestamp data.

Enhancements in #33 and #37 

<img width="546" alt="image" src="https://github.com/user-attachments/assets/6042269e-1e88-48db-aa3b-6aa5e973238c">

Replay widget:

<img width="305" alt="image" src="https://github.com/user-attachments/assets/1555fba7-6f07-413c-b005-d5295eefafbe">

# Proposed changes in follow-up PRs
1. Create track from VDR file.