### PR TITLE
Add support for recording N2K messages

### DIFF
--- a/Plugin.cmake
+++ b/Plugin.cmake
@@ -57,7 +57,7 @@ set(SRC
 )
 
 
-set(PKG_API_LIB api-19)  #  A directory in libs/ e. g., api-18 or api-19
+set(PKG_API_LIB api-18)  #  A directory in libs/ e. g., api-18 or api-19
 
 macro(late_init)
   # Perform initialization after the PACKAGE_NAME library, compilers

--- a/TEST-PLAN.md
+++ b/TEST-PLAN.md
@@ -1,0 +1,53 @@
+# VDR Plugin Test Plan
+
+## Basic Recording
+
+Disable auto-recording in preferences.
+
+- [ ] Manual start/stop recording via toolbar button.
+- [ ] Verify recorded files contain correct data format (raw NMEA or CSV).
+- [ ] Verify timestamp format in CSV output is in ISO 8601 format with UTC.
+- [ ] Check file rotation works at specified intervals.
+- [ ] Verify recording directory is created if doesn't exist.
+
+## Auto-Recording
+
+Enable auto-recording in preferences.
+
+- [ ] Verify recording auto-starts on plugin initialization.
+- [ ] Speed threshold start/stop.
+    - Start recording when speed exceeds threshold.
+    - Stop recording after delay when speed drops below threshold.
+    - Check hysteresis prevents rapid start/stop.
+    - Start recording again when speed exceeds threshold.
+    - Verify recording does not stop when no NMEA data is received. However nothing is written to the VDR file.
+- [ ] Verify manual stop disables auto-recording until speed drops below threshold.
+
+## Playback
+
+- [ ] Load and play NMEA file.
+- [ ] Load and play CSV file.
+- [ ] Pause/resume functionality.
+- [ ] Speed control (verify different playback speeds).
+- [ ] Progress bar navigation
+    - Drag while playing
+    - Drag while paused
+- [ ] Verify correct timestamp display.
+- [ ] End-of-file behavior
+    - Button changes to stop icon
+    - Restart from beginning works
+
+## Protocol Support
+
+- [ ] NMEA 0183 sentences recorded correctly
+- [ ] AIS messages recorded correctly
+- [ ] NMEA 2000 PGNs recorded correctly
+    - Basic PGNs (like position, heading)
+    - Proprietary messages
+
+## Settings
+
+- [ ] Save/load all preferences
+- [ ] Protocol enable/disable works
+- [ ] Directory selection persists
+- [ ] Format selection (NMEA/CSV) works

--- a/src/vdr_pi_prefs.cpp
+++ b/src/vdr_pi_prefs.cpp
@@ -29,6 +29,9 @@ enum {
   ID_VDR_LOG_ROTATE_CHECK,       // ID for log rotation checkbox
   ID_VDR_AUTO_RECORD_CHECK,      // ID for auto recording checkbox
   ID_USE_SPEED_THRESHOLD_CHECK,  // ID for speed threshold checkbox
+  ID_NMEA0183_CHECK,
+  ID_NMEA2000_CHECK,
+  ID_SIGNALK_CHECK
 };
 
 BEGIN_EVENT_TABLE(VDRPrefsDialog, wxDialog)
@@ -45,7 +48,8 @@ VDRPrefsDialog::VDRPrefsDialog(wxWindow* parent, wxWindowID id,
                                const wxString& recordingDir, bool logRotate,
                                int logRotateInterval, bool autoStartRecording,
                                bool useSpeedThreshold, double speedThreshold,
-                               int stopDelay)
+                               int stopDelay,
+                               const VDRProtocolSettings& protocols)
     : wxDialog(parent, id, _("VDR Preferences"), wxDefaultPosition,
                wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
       m_format(format),
@@ -55,7 +59,8 @@ VDRPrefsDialog::VDRPrefsDialog(wxWindow* parent, wxWindowID id,
       m_auto_start_recording(autoStartRecording),
       m_use_speed_threshold(useSpeedThreshold),
       m_speed_threshold(speedThreshold),
-      m_stop_delay(stopDelay) {
+      m_stop_delay(stopDelay),
+      m_protocols(protocols) {
   CreateControls();
   GetSizer()->Fit(this);
   GetSizer()->SetSizeHints(this);
@@ -80,6 +85,28 @@ void VDRPrefsDialog::UpdateControlStates() {
 void VDRPrefsDialog::CreateControls() {
   wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
   SetSizer(mainSizer);
+
+  // Protocol selection section
+  wxStaticBox* protocolBox =
+      new wxStaticBox(this, wxID_ANY, _("Recording Protocols"));
+  wxStaticBoxSizer* protocolSizer =
+      new wxStaticBoxSizer(protocolBox, wxVERTICAL);
+
+  m_nmea0183Check = new wxCheckBox(this, ID_NMEA0183_CHECK, _("NMEA 0183"));
+  m_nmea0183Check->SetValue(m_protocols.nmea0183);
+  protocolSizer->Add(m_nmea0183Check, 0, wxALL, 5);
+
+  m_nmea2000Check = new wxCheckBox(this, ID_NMEA2000_CHECK, _("NMEA 2000"));
+  m_nmea2000Check->SetValue(m_protocols.nmea2000);
+  protocolSizer->Add(m_nmea2000Check, 0, wxALL, 5);
+
+#if 0
+  m_signalKCheck = new wxCheckBox(this, ID_SIGNALK_CHECK, _("Signal K"));
+  m_signalKCheck->SetValue(m_protocols.signalK);
+  protocolSizer->Add(m_signalKCheck, 0, wxALL, 5);
+#endif
+
+  mainSizer->Add(protocolSizer, 0, wxEXPAND | wxALL, 5);
 
   // Add format choice
   wxStaticBox* formatBox =
@@ -206,6 +233,12 @@ void VDRPrefsDialog::OnOK(wxCommandEvent& event) {
   m_use_speed_threshold = m_useSpeedThresholdCheck->GetValue();
   m_speed_threshold = m_speedThresholdCtrl->GetValue();
   m_stop_delay = m_stopDelayCtrl->GetValue();
+
+  m_protocols.nmea0183 = m_nmea0183Check->GetValue();
+  m_protocols.nmea2000 = m_nmea2000Check->GetValue();
+#if 0
+  m_protocols.signalK = m_signalKCheck->GetValue();
+#endif
   event.Skip();
 }
 

--- a/src/vdr_pi_prefs.h
+++ b/src/vdr_pi_prefs.h
@@ -40,7 +40,8 @@ public:
   VDRPrefsDialog(wxWindow* parent, wxWindowID id, VDRDataFormat format,
                  const wxString& recordingDir, bool logRotate,
                  int logRotateInterval, bool autoStartRecording,
-                 bool useSpeedThreshold, double speedThreshold, int stopDelay);
+                 bool useSpeedThreshold, double speedThreshold, int stopDelay,
+                 const VDRProtocolSettings& protocols);
   VDRDataFormat GetDataFormat() const { return m_format; }
   wxString GetRecordingDir() const { return m_recording_dir; }
   bool GetLogRotate() const { return m_log_rotate; }
@@ -49,6 +50,7 @@ public:
   bool GetUseSpeedThreshold() const { return m_use_speed_threshold; }
   double GetSpeedThreshold() const { return m_speed_threshold; }
   int GetStopDelay() const { return m_stop_delay; }
+  VDRProtocolSettings GetProtocolSettings() const { return m_protocols; }
 
 private:
   void OnOK(wxCommandEvent& event);
@@ -72,6 +74,13 @@ private:
   wxSpinCtrlDouble* m_speedThresholdCtrl;
   wxSpinCtrl* m_stopDelayCtrl;
 
+  // Protocol selection checkboxes
+  wxCheckBox* m_nmea0183Check;
+  wxCheckBox* m_nmea2000Check;
+#if 0
+  wxCheckBox* m_signalKCheck;
+#endif
+
   VDRDataFormat m_format;
   wxString m_recording_dir;
   bool m_log_rotate;
@@ -80,6 +89,8 @@ private:
   bool m_use_speed_threshold;   // Use speed threshold for auto recording.
   double m_speed_threshold;     // Speed threshold for auto recording.
   int m_stop_delay;             // Minutes to wait before stopping.
+
+  VDRProtocolSettings m_protocols;
 
   DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
1. Add support for recording NMEA 2000 messages (#45).
2. Set plugin API dependency to 1.18. Previously it was set to 1.19, but it turns out 1.19 is not yet supported on Android, and 1.18 is sufficient for recording NMEA 2000 messages.
3. Handle scenario when user changes output format (CSV <=> raw) while recording is in progress.
4. If auto-start has been enabled with speed threshold, and recording has been triggered: if subsequently user stops recording, we should't immediately restart recording just because the speed is above the threshold. The user signified intent to stop recording.
5. Add stub implementation for SignalK.

Follow-up work:
1. Add SignalK. I don't have SignalK simulator and I think this is worth splitting in two separate PRs anyway.
2. When https://github.com/OpenCPN/OpenCPN/pull/4267 is supported, automatically bind these PGNs instead of hard-coding the NMEA2000 PGNs.

The VDR Preferences look like this:

<img width="420" alt="image" src="https://github.com/user-attachments/assets/393200c6-b92b-4bb7-ba05-6ce70c8790d2" />
