### PR TITLE
Upgrade to plugin API 1.19, Fix Android build

### DIFF
--- a/Plugin.cmake
+++ b/Plugin.cmake
@@ -57,7 +57,7 @@ set(SRC
 )
 
 
-set(PKG_API_LIB api-17)  #  A directory in libs/ e. g., api-17 or api-16
+set(PKG_API_LIB api-19)  #  A directory in libs/ e. g., api-18 or api-19
 
 macro(late_init)
   # Perform initialization after the PACKAGE_NAME library, compilers

--- a/src/vdr_pi.cpp
+++ b/src/vdr_pi.cpp
@@ -162,6 +162,7 @@ bool vdr_pi::DeInit(void) {
     m_ostream.Close();
     m_recording = false;
 #ifdef __ANDROID__
+    bool AndroidSecureCopyFile(wxString in, wxString out);
     AndroidSecureCopyFile(m_temp_outfile, m_final_outfile);
     ::wxRemoveFile(m_temp_outfile);
 #endif
@@ -726,6 +727,7 @@ void vdr_pi::StopRecording() {
   m_auto_recording_active = false;
 
 #ifdef __ANDROID__
+  bool AndroidSecureCopyFile(wxString in, wxString out);
   AndroidSecureCopyFile(m_temp_outfile, m_final_outfile);
   ::wxRemoveFile(m_temp_outfile);
 #endif


### PR DESCRIPTION
1. Upgrade to OpenCPN plugin API version 1.19
2. Fix Android build issue.

All builds are successful. Yeah!