### PR TITLE
Fix sub-second parsing in RMC and ZDA sentences

### DIFF
--- a/src/vdr_pi.h
+++ b/src/vdr_pi.h
@@ -184,6 +184,7 @@ public:
    */
   void CheckAutoRecording(double speed);
   bool HasValidTimestamps() const;
+  const wxString& GetFileStatus() const { return m_fileStatus; }
 
 private:
   class TimerHandler : public wxTimer {
@@ -318,6 +319,7 @@ private:
   int m_stop_delay;  // Minutes to wait before stopping.
   /** When speed first dropped below threshold. */
   wxDateTime m_below_threshold_since;
+  wxString m_fileStatus;
 
   wxEvtHandler* m_eventHandler;
   TimerHandler* m_timer;
@@ -359,6 +361,7 @@ private:
   wxSlider* m_progressSlider;
   wxStaticText* m_fileLabel;
   wxStaticText* m_timeLabel;
+  wxStaticText* m_statusLabel;
   vdr_pi* m_pvdr;
 
   bool m_isDragging;


### PR DESCRIPTION
Fix #55 

This is WIP.

## Issue 1: Parsing Sub-seconds in RMC and ZDA sentences

In `Tactics-sample1-12m.txt`, timestamps have milliseconds precision, e.g. `085349.800` is time in UTC  (08:53:49.800), which is supported by the NMEA standard. For example:

```
$GPRMC,085349.800,A,4503.7389,N,01338.8654,E,3.33,185.16,060516,,,D*6D
```

The code was incorrectly parsing sub-seconds.

## Issue 2: Log timestamps when time is not monotonically increasing.

Logging the timestamps helps to troubleshoot discontinuities, i.e. when the timestamps move backwards in time. Example:
```
17:44:01.506 MESSAGE vdr_pi.cpp:1128 VDR file contains non-monotonically increasing timestamps.
   Previous ts: 2016-05-06T15:53:51.600Z, Current ts: 2016-05-06T15:53:51.000Z
```

This helped to identify a scenario when one sentence has millisecond precision (`RMC` below) followed by another sentence that does not have millisecond precision (`ZDA` below).

$GPRMC,085351.600,A,4503.7374,N,01338.8651,E,3.32,190.94,060516,,,D*62
$IIZDA,085351,06,05,2016,,*53

## Issue 3: Be lenient and ignore small time backward jumps

When one sentence has millisecond precision (`RMC` below) followed by another sentence that does not have millisecond precision (`ZDA` below), we get something like this:

```
$GPRMC,085351.600,A,4503.7374,N,01338.8651,E,3.32,190.94,060516,,,D*62
$IIZDA,085351,06,05,2016,,*53
```

A naive interpretation is that the time goes backwards. We should ignore small backward jumps.

## Issue 4: Add file status to indicate why timestamps are not displayed

Reasons could be:
1. Timestamps are not in chronological order.
2. There are no RMC or ZDA sentences.

<img width="351" alt="image" src="https://github.com/user-attachments/assets/5eb15769-0740-4dc3-b175-7cab585f8cba" />

