### PR TITLE
Bigger margins, fit widget size, slightly bigger icons

### DIFF
--- a/src/vdr_pi.cpp
+++ b/src/vdr_pi.cpp
@@ -1517,25 +1517,29 @@ VDRControl::VDRControl(wxWindow* parent, wxWindowID id, vdr_pi* vdr)
     }
   }
 }
+
 void VDRControl::CreateControls() {
   // Main vertical sizer
   wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
 
+  wxSize buttonDimension(32, 32);
   // File information section
   wxBoxSizer* fileSizer = new wxBoxSizer(wxHORIZONTAL);
   m_loadBtn = new wxButton(this, ID_VDR_LOAD, wxString::FromUTF8("📂"),
-                           wxDefaultPosition, wxDefaultSize, 0);
-  wxSize loadButtonSize(25, 25);
-  m_loadBtn->SetMinSize(loadButtonSize);
-  m_loadBtn->SetInitialSize(loadButtonSize);
+                           wxDefaultPosition, buttonDimension, wxBU_EXACTFIT);
+  wxFont buttonFont = m_loadBtn->GetFont();
+  buttonFont.SetPointSize(static_cast<int>(buttonFont.GetPointSize() * 1.3));
+  m_loadBtn->SetFont(buttonFont);
+  m_loadBtn->SetMinSize(buttonDimension);
+  m_loadBtn->SetMaxSize(buttonDimension);
   m_loadBtn->SetToolTip(_("Load VDR File"));
-  fileSizer->Add(m_loadBtn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
+  fileSizer->Add(m_loadBtn, 0, wxALL, 2);
 
   m_fileLabel =
       new wxStaticText(this, wxID_ANY, _("No file loaded"), wxDefaultPosition,
                        wxDefaultSize, wxST_ELLIPSIZE_START);
-  fileSizer->Add(m_fileLabel, 1, wxEXPAND | wxALL | wxALIGN_CENTER_VERTICAL, 2);
-  mainSizer->Add(fileSizer, 0, wxEXPAND | wxALL, 2);
+  fileSizer->Add(m_fileLabel, 1, wxALL | wxALIGN_CENTER_VERTICAL, 2);
+  mainSizer->Add(fileSizer, 0, wxALL, 4);
 
   // Play controls and progress in one row
   wxBoxSizer* controlSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -1547,27 +1551,24 @@ void VDRControl::CreateControls() {
 
   m_playPauseBtn =
       new wxButton(this, ID_VDR_PLAY_PAUSE, wxString::FromUTF8("▶"),
-                   wxDefaultPosition, wxDefaultSize, 0);
-  wxSize buttonSize(25, 25);
-  m_playPauseBtn->SetMinSize(buttonSize);
-  m_playPauseBtn->SetInitialSize(buttonSize);
-  wxFont font = m_playPauseBtn->GetFont();
-  font.SetPointSize(font.GetPointSize() * 1.2);
-  m_playPauseBtn->SetFont(font);
+                   wxDefaultPosition, buttonDimension, wxBU_EXACTFIT);
+  m_playPauseBtn->SetMinSize(buttonDimension);
+  m_playPauseBtn->SetMaxSize(buttonDimension);
+  m_playPauseBtn->SetFont(buttonFont);
   m_playPauseBtn->SetToolTip(m_playBtnTooltip);
-  controlSizer->Add(m_playPauseBtn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 3);
+  controlSizer->Add(m_playPauseBtn, 0, wxALL, 3);
 
   // Progress slider in the same row as play button
   m_progressSlider =
       new wxSlider(this, ID_VDR_PROGRESS, 0, 0, 1000, wxDefaultPosition,
                    wxDefaultSize, wxSL_HORIZONTAL | wxSL_BOTTOM);
-  controlSizer->Add(m_progressSlider, 1, wxEXPAND | wxALIGN_CENTER_VERTICAL, 0);
-  mainSizer->Add(controlSizer, 0, wxEXPAND | wxALL, 2);
+  controlSizer->Add(m_progressSlider, 1, wxALIGN_CENTER_VERTICAL, 0);
+  mainSizer->Add(controlSizer, 0, wxEXPAND | wxALL, 4);
 
   // Time label
   m_timeLabel = new wxStaticText(this, wxID_ANY, _("Date and Time: --"),
                                  wxDefaultPosition, wxSize(200, -1));
-  mainSizer->Add(m_timeLabel, 0, wxEXPAND | wxALL, 2);
+  mainSizer->Add(m_timeLabel, 0, wxEXPAND | wxALL, 4);
 
   // Speed control
   wxBoxSizer* speedSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -1577,16 +1578,19 @@ void VDRControl::CreateControls() {
       new wxSlider(this, wxID_ANY, 1, 1, 100, wxDefaultPosition, wxDefaultSize,
                    wxSL_HORIZONTAL | wxSL_VALUE_LABEL);
   speedSizer->Add(m_speedSlider, 1, wxEXPAND | wxALIGN_CENTER_VERTICAL, 0);
-  mainSizer->Add(speedSizer, 0, wxEXPAND | wxALL, 2);
+  mainSizer->Add(speedSizer, 0, wxEXPAND | wxALL, 4);
 
   // Status label (info/error messages).
   m_statusLabel = new wxStaticText(this, wxID_ANY, wxEmptyString);
-  mainSizer->Add(m_statusLabel, 0, wxEXPAND | wxALL, 5);
+  mainSizer->Add(m_statusLabel, 0, wxEXPAND | wxALL, 4);
 
   SetSizer(mainSizer);
-  mainSizer->SetMinSize(wxSize(350, -1));
-  mainSizer->Fit(this);
+  wxClientDC dc(m_timeLabel);
+  wxSize textExtent = dc.GetTextExtent(_("Date and Time: YYYY-MM-DD HH:MM:SS"));
+  int minWidth = std::max(100, textExtent.GetWidth() + 20);  // 20px padding
+  mainSizer->SetMinSize(wxSize(minWidth, -1));
   Layout();
+  mainSizer->Fit(this);
 
   // Initial state
   UpdateControls();


### PR DESCRIPTION
Fix for #62 
1. Slightly bigger margins.
2. Add logic to fit the width of the replay control window based on the length of the date/time text.
3. Slightly bigger icons.

![Uploading image.png…]()
