### PR TITLE
Auto-adjust size of load and play/pause buttons for high DPI displays

### DIFF
--- a/src/vdr_pi.cpp
+++ b/src/vdr_pi.cpp
@@ -34,6 +34,7 @@
 
 #include "wx/tokenzr.h"
 #include "wx/statline.h"
+#include "wx/display.h"
 
 #include <map>
 #include <typeinfo>
@@ -1558,14 +1559,19 @@ void VDRControl::CreateControls() {
   // Main vertical sizer
   wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
 
-  wxSize buttonDimension(32, 32);
+  wxFont* buttonFont = GetOCPNScaledFont_PlugIn("Dialog", 14);
+  // Calculate button dimensions based on font height
+  int fontHeight = buttonFont->GetPointSize();
+  int buttonSize = fontHeight * 1.5;  // Adjust multiplier as needed
+  // Ensure minimum size of 32 pixels for touch usability
+  buttonSize = std::max(buttonSize, 32);
+  wxSize buttonDimension(buttonSize, buttonSize);
+
   // File information section
   wxBoxSizer* fileSizer = new wxBoxSizer(wxHORIZONTAL);
   m_loadBtn = new wxButton(this, ID_VDR_LOAD, wxString::FromUTF8("📂"),
                            wxDefaultPosition, buttonDimension, wxBU_EXACTFIT);
-  wxFont buttonFont = m_loadBtn->GetFont();
-  buttonFont.SetPointSize(static_cast<int>(buttonFont.GetPointSize() * 1.3));
-  m_loadBtn->SetFont(buttonFont);
+  m_loadBtn->SetFont(*buttonFont);
   m_loadBtn->SetMinSize(buttonDimension);
   m_loadBtn->SetMaxSize(buttonDimension);
   m_loadBtn->SetToolTip(_("Load VDR File"));
@@ -1588,9 +1594,9 @@ void VDRControl::CreateControls() {
   m_playPauseBtn =
       new wxButton(this, ID_VDR_PLAY_PAUSE, wxString::FromUTF8("▶"),
                    wxDefaultPosition, buttonDimension, wxBU_EXACTFIT);
+  m_playPauseBtn->SetFont(*buttonFont);
   m_playPauseBtn->SetMinSize(buttonDimension);
   m_playPauseBtn->SetMaxSize(buttonDimension);
-  m_playPauseBtn->SetFont(buttonFont);
   m_playPauseBtn->SetToolTip(m_playBtnTooltip);
   controlSizer->Add(m_playPauseBtn, 0, wxALL, 3);
 


### PR DESCRIPTION
This PR fixes the size of the **load** and **play/pause** buttons in the VDR replay control panel.

As I was going through the wxWidget API and OpenCPN plugin API code, I documented the plugin APIs in https://github.com/OpenCPN/OpenCPN/pull/4287, i.e. to better understand the purpose of these functions:
```c++
wxFont* OCPNGetFont
wxFont* GetOCPNScaledFont_PlugIn
wxFont GetOCPNGUIScaledFont_PlugIn
wxFont* FindOrCreateFont_PlugIn
```

Base on these findings, it seems the right thing to do is to invoke the `GetOCPNScaledFont_PlugIn` function. I  discovered bug https://github.com/OpenCPN/OpenCPN/issues/4288 while reading the code and testing.

I'm not able to actually test on Android as no reproducible build instructions are available, but hopefully this should fix the icon size issue.