### PR TITLE
Auto-adjust button size based DPI.

### DIFF
--- a/src/vdr_pi.cpp
+++ b/src/vdr_pi.cpp
@@ -1559,10 +1559,13 @@ void VDRControl::CreateControls() {
   // Main vertical sizer
   wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
 
-  wxFont* buttonFont = GetOCPNScaledFont_PlugIn("Dialog", 14);
+  wxFont* baseFont = GetOCPNScaledFont_PlugIn("Dialog", 0);
+  wxFont* buttonFont = FindOrCreateFont_PlugIn(
+      baseFont->GetPointSize() * GetContentScaleFactor(), baseFont->GetFamily(),
+      baseFont->GetStyle(), baseFont->GetWeight());
   // Calculate button dimensions based on font height
   int fontHeight = buttonFont->GetPointSize();
-  int buttonSize = fontHeight * 1.5;  // Adjust multiplier as needed
+  int buttonSize = fontHeight * 1.2;  // Adjust multiplier as needed
   // Ensure minimum size of 32 pixels for touch usability
   buttonSize = std::max(buttonSize, 32);
   wxSize buttonDimension(buttonSize, buttonSize);


### PR DESCRIPTION
Sorry for the repeated changes here, but it's not obvious what the font functions in https://github.com/OpenCPN/OpenCPN/pull/4287 are 1) supposed to do, and 2) actually doing,

I just realized the scaling of the fonts is only enabled when `g_bresponsive == true`. I'm not sure why. IMHO, it would be a lot simpler if the fonts were scaled based on the DPI value.