### PR TITLE
Add settings button in VDR control panel

### DIFF
--- a/src/vdr_pi.cpp
+++ b/src/vdr_pi.cpp
@@ -1512,7 +1512,8 @@ enum {
   ID_VDR_PLAY_PAUSE,
   ID_VDR_DATA_FORMAT_RADIOBUTTON,
   ID_VDR_SPEED_SLIDER,
-  ID_VDR_PROGRESS
+  ID_VDR_PROGRESS,
+  ID_VDR_SETTINGS
 };
 
 BEGIN_EVENT_TABLE(VDRControl, wxWindow)
@@ -1520,6 +1521,7 @@ EVT_BUTTON(ID_VDR_LOAD, VDRControl::OnLoadButton)
 EVT_RADIOBUTTON(ID_VDR_DATA_FORMAT_RADIOBUTTON,
                 VDRControl::OnDataFormatRadioButton)
 EVT_BUTTON(ID_VDR_PLAY_PAUSE, VDRControl::OnPlayPauseButton)
+EVT_BUTTON(ID_VDR_SETTINGS, VDRControl::OnSettingsButton)
 EVT_SLIDER(ID_VDR_SPEED_SLIDER, VDRControl::OnSpeedSliderUpdated)
 EVT_COMMAND_SCROLL_THUMBTRACK(ID_VDR_PROGRESS,
                               VDRControl::OnProgressSliderUpdated)
@@ -1569,6 +1571,18 @@ void VDRControl::CreateControls() {
 
   // File information section
   wxBoxSizer* fileSizer = new wxBoxSizer(wxHORIZONTAL);
+
+  // Settings button
+  m_settingsBtn =
+      new wxButton(this, ID_VDR_SETTINGS, wxString::FromUTF8("⚙️"),
+                   wxDefaultPosition, buttonDimension, wxBU_EXACTFIT);
+  m_settingsBtn->SetFont(*buttonFont);
+  m_settingsBtn->SetMinSize(buttonDimension);
+  m_settingsBtn->SetMaxSize(buttonDimension);
+  m_settingsBtn->SetToolTip(_("Settings"));
+  fileSizer->Add(m_settingsBtn, 0, wxALL, 2);
+
+  // Load button
   m_loadBtn = new wxButton(this, ID_VDR_LOAD, wxString::FromUTF8("📂"),
                            wxDefaultPosition, buttonDimension, wxBU_EXACTFIT);
   m_loadBtn->SetFont(*buttonFont);
@@ -1581,6 +1595,7 @@ void VDRControl::CreateControls() {
       new wxStaticText(this, wxID_ANY, _("No file loaded"), wxDefaultPosition,
                        wxDefaultSize, wxST_ELLIPSIZE_START);
   fileSizer->Add(m_fileLabel, 1, wxALL | wxALIGN_CENTER_VERTICAL, 2);
+
   mainSizer->Add(fileSizer, 0, wxALL, 4);
 
   // Play controls and progress in one row
@@ -1768,6 +1783,7 @@ void VDRControl::UpdateControls() {
   // Enable/disable controls based on state
   m_loadBtn->Enable(!isRecording && !isPlaying);
   m_playPauseBtn->Enable(hasFile && !isRecording);
+  m_settingsBtn->Enable(!isPlaying && !isRecording);
   m_progressSlider->Enable(hasFile && !isRecording);
 
   // Update toolbar state
@@ -1821,6 +1837,11 @@ void VDRControl::OnPlayPauseButton(wxCommandEvent& event) {
 void VDRControl::OnDataFormatRadioButton(wxCommandEvent& event) {
   // Radio button state is tracked by wx, we just need to handle any
   // format-specific UI updates here if needed in the future
+}
+
+void VDRControl::OnSettingsButton(wxCommandEvent& event) {
+  m_pvdr->ShowPreferencesDialog(this);
+  event.Skip();
 }
 
 void VDRControl::OnSpeedSliderUpdated(wxCommandEvent& event) {

--- a/src/vdr_pi.h
+++ b/src/vdr_pi.h
@@ -614,7 +614,11 @@ private:
   /** Handle data format selection changes. */
   void OnDataFormatRadioButton(wxCommandEvent& event);
 
+  /** Handle left-click on Settings button. */
+  void OnSettingsButton(wxCommandEvent& event);
+
   wxButton* m_loadBtn;         //!< Button to load VDR file
+  wxButton* m_settingsBtn;     //!< Button to open settings dialog
   wxButton* m_playPauseBtn;    //!< Toggle button for play/pause
   wxString m_playBtnTooltip;   //!< Tooltip text for play state
   wxString m_pauseBtnTooltip;  //!< Tooltip text for pause state


### PR DESCRIPTION
# Description

This PR adds a settings (⚙️) button to the VDR plugin's replay panel interface, providing direct access to the preferences dialog from the main control panel.

Fix #59 

# Changes

1. Added a settings button before to the file load button in the VDR control panel
1. Button is styled consistently with existing controls and uses the same dimensions
1. Settings button is automatically disabled during playback or recording to prevent configuration changes during active operations
1. Clicking the button opens the existing preferences dialog
1. Added appropriate tooltips and accessibility labels

The new button improves usability by:
1. Making settings more discoverable and accessible
2. Reducing the number of clicks needed to adjust plugin preferences
3. Providing a more intuitive interface for users

<img width="607" alt="image" src="https://github.com/user-attachments/assets/f43d27c8-3dfe-4074-8477-c479cffe55ef" />
