### PR TITLE
#78 - set playing to false just like recording on creation.

### DIFF
--- a/Plugin.cmake
+++ b/Plugin.cmake
@@ -31,7 +31,7 @@ option(VDR_USE_SVG "Use SVG graphics" ON)
 # -------  Plugin setup --------
 #
 set(PKG_NAME vdr_pi)
-set(PKG_VERSION  1.3.53.0)
+set(PKG_VERSION  1.3.54.0)
 set(PKG_PRERELEASE "")  # Empty, or a tag like 'beta'
 
 set(DISPLAY_NAME VDR)    # Dialogs, installer artifacts, ...

--- a/src/vdr_pi.cpp
+++ b/src/vdr_pi.cpp
@@ -92,6 +92,7 @@ vdr_pi::vdr_pi(void* ppimgr) : opencpn_plugin_118(ppimgr) {
   // Runtime variables
   m_recording = false;
   m_recording_paused = false;
+  m_playing = false;
   m_is_csv_file = false;
   m_last_speed = 0.0;
   m_sentence_buffer.clear();


### PR DESCRIPTION
Nothing should be playing back when openCPN starts. This resolves #78 