### PR TITLE
Allow alternate talkers for NMEA0183 RMC sentences.

### DIFF
--- a/Plugin.cmake
+++ b/Plugin.cmake
@@ -31,7 +31,7 @@ option(VDR_USE_SVG "Use SVG graphics" ON)
 # -------  Plugin setup --------
 #
 set(PKG_NAME vdr_pi)
-set(PKG_VERSION  1.3.53.0)
+set(PKG_VERSION  1.3.55.0)
 set(PKG_PRERELEASE "")  # Empty, or a tag like 'beta'
 
 set(DISPLAY_NAME VDR)    # Dialogs, installer artifacts, ...

--- a/src/vdr_pi.cpp
+++ b/src/vdr_pi.cpp
@@ -389,7 +389,9 @@ void vdr_pi::SetNMEASentence(wxString& sentence) {
     return;
   }
   // Check for RMC sentence to get speed and check for auto-recording.
-  if (sentence.StartsWith("$GPRMC") || sentence.StartsWith("$GNRMC")) {
+  // There can be different talkers on the stream so look at the message type
+  // irespective of the talker
+  if (sentence.size() >= 6 && sentence.substr(3, 3) == "RMC") {
     wxStringTokenizer tkz(sentence, wxT(","));
     wxString token;
 


### PR DESCRIPTION
Check for the RMC type of NMEA sentence instead of the full sentence header that is talker specific.

This resolves #80