### PR TITLE
Support for replaying NMEA over TCP/UDP network

### DIFF
--- a/Plugin.cmake
+++ b/Plugin.cmake
@@ -54,8 +54,14 @@ set(SRC
   src/vdr_pi.cpp
   src/vdr_pi_prefs.h
   src/vdr_pi_prefs.cpp
+  src/vdr_pi_control.h
+  src/vdr_pi_control.cpp
+  src/vdr_pi_prefs_net.h
+  src/vdr_pi_prefs_net.cpp
   src/vdr_pi_time.h
   src/vdr_pi_time.cpp
+  src/vdr_network.h
+  src/vdr_network.cpp
 )
 
 

--- a/src/vdr_network.cpp
+++ b/src/vdr_network.cpp
@@ -1,0 +1,253 @@
+/***************************************************************************
+ *   Copyright (C) 2024 by OpenCPN development team                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ **************************************************************************/
+
+#include "vdr_network.h"
+
+#include <algorithm>
+
+// Socket event IDs
+enum { SOCKET_ID = 5000, SERVER_ID };
+
+BEGIN_EVENT_TABLE(VDRNetworkServer, wxEvtHandler)
+EVT_SOCKET(SERVER_ID, VDRNetworkServer::OnTcpEvent)
+EVT_SOCKET(SOCKET_ID, VDRNetworkServer::OnTcpEvent)
+END_EVENT_TABLE()
+
+VDRNetworkServer::VDRNetworkServer()
+    : m_tcpServer(nullptr),
+      m_udpSocket(nullptr),
+      m_running(false),
+      m_useTCP(true),
+      m_port(DEFAULT_PORT) {
+  // Initialize socket handling
+  wxSocketBase::Initialize();
+}
+
+VDRNetworkServer::~VDRNetworkServer() {
+  if (m_running) {
+    Stop();
+  }
+}
+
+bool VDRNetworkServer::Start(bool useTCP, int port, wxString& error) {
+  // Don't start if already running
+  if (m_running) {
+    Stop();  // Stop first to reconfigure
+  }
+
+  m_useTCP = useTCP;
+  m_port = port;
+
+  // Validate port number
+  if (port < 1024 || port > 65535) {
+    error = wxString::Format(_("Invalid port %d (must be 1024-65535)"), port);
+    wxLogMessage(error);
+    return false;
+  }
+
+  bool success = m_useTCP ? InitTCP(port, error) : InitUDP(port, error);
+
+  if (success) {
+    m_running = true;
+    error = wxEmptyString;
+    wxLogMessage("VDR Network Server started - %s on port %d",
+                 m_useTCP ? "TCP" : "UDP", m_port);
+  }
+  return success;
+}
+
+void VDRNetworkServer::Stop() {
+  if (m_tcpServer) {
+    m_tcpServer->Notify(false);
+    delete m_tcpServer;
+    m_tcpServer = nullptr;
+  }
+
+  if (m_udpSocket) {
+    delete m_udpSocket;
+    m_udpSocket = nullptr;
+  }
+
+  m_tcpClients.clear();
+  m_running = false;
+}
+
+bool VDRNetworkServer::SendText(const wxString& message) {
+  if (!m_running) {
+    return false;
+  }
+
+  // Ensure message ends with proper line ending
+  wxString formattedMsg = message;
+  if (!formattedMsg.EndsWith("\r\n")) {
+    formattedMsg += "\r\n";
+  }
+  return SendImpl(formattedMsg.c_str(), formattedMsg.Length());
+}
+
+bool VDRNetworkServer::SendBinary(const void* data, size_t length) {
+  if (!m_running || !data || length == 0) {
+    return false;
+  }
+
+  return SendImpl(data, length);
+}
+
+bool VDRNetworkServer::SendImpl(const void* data, size_t length) {
+  if (m_useTCP) {
+    // Remove any dead connections before sending
+    CleanupDeadConnections();
+
+    // Send to all TCP clients
+    bool success = true;
+    for (auto client : m_tcpClients) {
+      client->Write(data, length);
+      if (client->Error()) {
+        success = false;
+      }
+    }
+    return success && !m_tcpClients.empty();
+  } else {
+    // Send UDP broadcast to localhost
+    if (m_udpSocket) {
+      wxIPV4address destAddr;
+      destAddr.Hostname("127.0.0.1");
+      destAddr.Service(m_port);  // Target port (10110 typically)
+
+      m_udpSocket->SendTo(destAddr, data, length);
+      return !m_udpSocket->Error();
+    }
+  }
+  return false;
+}
+
+bool VDRNetworkServer::InitTCP(int port, wxString& error) {
+  wxIPV4address addr;
+  if (!addr.Hostname("127.0.0.1")) {
+    error = _("Failed to set TCP socket hostname");
+    wxLogMessage(error);
+    return false;
+  }
+
+  if (!addr.Service(port)) {
+    error = wxString::Format(_("Failed to set TCP port %d"), port);
+    wxLogMessage(error);
+    return false;
+  }
+
+  // Create new server socket
+  if (m_tcpServer) {
+    delete m_tcpServer;
+    m_tcpServer = nullptr;
+  }
+
+  m_tcpServer = new wxSocketServer(addr);
+
+  // Check socket state
+  if (!m_tcpServer->IsOk()) {
+    error = _("TCP server init failed");
+    wxLogMessage(error);
+    delete m_tcpServer;
+    m_tcpServer = nullptr;
+    return false;
+  }
+
+  m_tcpServer->SetEventHandler(*this);
+  // Indicate that we want to be notified on connection events.
+  m_tcpServer->SetNotify(wxSOCKET_CONNECTION_FLAG);
+  // Enable the event notifications.
+  m_tcpServer->Notify(true);
+  error = wxEmptyString;
+  wxLogMessage("TCP server initialized on port %d", port);
+  return true;
+}
+
+bool VDRNetworkServer::InitUDP(int port, wxString& error) {
+  // Create new socket
+  if (m_udpSocket) {
+    delete m_udpSocket;
+    m_udpSocket = nullptr;
+  }
+
+  wxIPV4address addr;
+  addr.AnyAddress();
+  addr.Service(0);  // Use ephemeral port for sending
+
+  m_udpSocket = new wxDatagramSocket(addr, wxSOCKET_NOWAIT);
+  // Check socket state
+  if (!m_udpSocket->IsOk()) {
+    error = _("UDP socket init failed");
+    wxLogMessage(error);
+    delete m_udpSocket;
+    m_udpSocket = nullptr;
+    return false;
+  }
+  error = wxEmptyString;
+  wxLogMessage("UDP server initialized on port %d", port);
+  return true;
+}
+
+void VDRNetworkServer::OnTcpEvent(wxSocketEvent& event) {
+  switch (event.GetSocketEvent()) {
+    case wxSOCKET_CONNECTION: {
+      // Accept new client connection
+      wxSocketBase* client = m_tcpServer->Accept(false);
+      if (client) {
+        client->SetEventHandler(*this, SOCKET_ID);
+        client->SetNotify(wxSOCKET_LOST_FLAG);
+        client->Notify(true);
+        m_tcpClients.push_back(client);
+        wxLogMessage("New TCP client connected. Total clients: %zu",
+                     m_tcpClients.size());
+      }
+      break;
+    }
+
+    case wxSOCKET_LOST: {
+      // Handle client disconnection
+      wxSocketBase* client = event.GetSocket();
+      if (client) {
+        auto it = std::find(m_tcpClients.begin(), m_tcpClients.end(), client);
+        if (it != m_tcpClients.end()) {
+          m_tcpClients.erase(it);
+          client->Destroy();
+          wxLogMessage("TCP client disconnected. Remaining clients: %zu",
+                       m_tcpClients.size());
+        }
+      }
+      break;
+    }
+
+    default:
+      break;
+  }
+}
+
+void VDRNetworkServer::CleanupDeadConnections() {
+  auto it = m_tcpClients.begin();
+  while (it != m_tcpClients.end()) {
+    wxSocketBase* client = *it;
+    if (!client || !client->IsConnected()) {
+      delete client;
+      it = m_tcpClients.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}

--- a/src/vdr_network.h
+++ b/src/vdr_network.h
@@ -1,0 +1,126 @@
+/***************************************************************************
+ *   Copyright (C) 2024 by OpenCPN development team                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ **************************************************************************/
+
+#ifndef _VDR_NETWORK_H_
+#define _VDR_NETWORK_H_
+
+#include <wx/wx.h>
+#include <wx/socket.h>
+
+#include <vector>
+#include <memory>
+
+// Forward declarations
+class wxSocketServer;
+class wxDatagramSocket;
+class wxSocketEvent;
+
+/**
+ * Network server for replaying NMEA messages over TCP or UDP.
+ *
+ * Provides a server that can listen on a specified port and protocol (TCP/UDP)
+ * and broadcast messages to connected clients. For TCP, maintains a list of
+ * connected clients. For UDP, broadcasts to localhost on the specified port.
+ */
+class VDRNetworkServer : public wxEvtHandler {
+public:
+  /** Constructor initializes server state. */
+  VDRNetworkServer();
+
+  /** Destructor ensures proper cleanup of sockets. */
+  ~VDRNetworkServer();
+
+  /**
+   * Start the network server.
+   *
+   * @param useTCP True to use TCP, false for UDP.
+   * @param port Port number to listen on.
+   * * @param error Will contain error message if start fails
+   * @return True if server started successfully
+   */
+  bool Start(bool useTCP, int port, wxString& error);
+
+  /** Stop the server and cleanup all connections. */
+  void Stop();
+
+  /**
+   * Send a text message to all connected clients
+   *
+   * For text-based formats like SeaSmart ($PCDIN), Actisense ASCII, etc.
+   * Automatically adds line endings if needed.
+   *
+   * @param message Text message to send
+   * @return True if message was sent successfully
+   */
+  bool SendText(const wxString& message);
+
+  /**
+   * Send binary data to all connected clients
+   *
+   * For binary formats like Actisense N2K, RAW, NGT.
+   * Sends data exactly as provided without any modification.
+   *
+   * @param data Pointer to binary data
+   * @param length Length of data in bytes
+   * @return True if data was sent successfully
+   */
+  bool SendBinary(const void* data, size_t length);
+
+  /** Check if server is currently running. */
+  bool IsRunning() const { return m_running; }
+
+  /** Get current protocol (TCP/UDP). */
+  bool IsTCP() const { return m_useTCP; }
+
+  /** Get current port number. */
+  int GetPort() const { return m_port; }
+
+private:
+  /** Handle incoming TCP socket events. */
+  void OnTcpEvent(wxSocketEvent& event);
+
+  /** Remove any dead or disconnected TCP clients. */
+  void CleanupDeadConnections();
+
+  /** Initialize TCP server. */
+  bool InitTCP(int port, wxString& error);
+
+  /** Initialize UDP server. */
+  bool InitUDP(int port, wxString& error);
+
+  /**
+   * Internal send implementation.
+   * Handles the actual sending of data for both TCP and UDP.
+   */
+  bool SendImpl(const void* data, size_t length);
+
+private:
+  wxSocketServer* m_tcpServer;              //!< TCP server socket
+  wxDatagramSocket* m_udpSocket;            //!< UDP socket
+  std::vector<wxSocketBase*> m_tcpClients;  //!< Connected TCP clients
+  bool m_running;                           //!< Server running state
+  bool m_useTCP;                            //!< Current protocol
+  int m_port;                               //!< Current port
+
+  static const int DEFAULT_PORT = 10111;  //!< Default NMEA port
+
+  DECLARE_EVENT_TABLE()
+};
+
+#endif  // _VDR_NETWORK_H_

--- a/src/vdr_pi_control.cpp
+++ b/src/vdr_pi_control.cpp
@@ -1,0 +1,442 @@
+/***************************************************************************
+ *   Copyright (C) 2024 by OpenCPN development team                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ **************************************************************************/
+
+#include "vdr_pi_control.h"
+#include "vdr_pi.h"
+
+enum {
+  ID_VDR_LOAD = wxID_HIGHEST + 1,
+  ID_VDR_PLAY_PAUSE,
+  ID_VDR_DATA_FORMAT_RADIOBUTTON,
+  ID_VDR_SPEED_SLIDER,
+  ID_VDR_PROGRESS,
+  ID_VDR_SETTINGS
+};
+
+BEGIN_EVENT_TABLE(VDRControl, wxWindow)
+EVT_BUTTON(ID_VDR_LOAD, VDRControl::OnLoadButton)
+EVT_RADIOBUTTON(ID_VDR_DATA_FORMAT_RADIOBUTTON,
+                VDRControl::OnDataFormatRadioButton)
+EVT_BUTTON(ID_VDR_PLAY_PAUSE, VDRControl::OnPlayPauseButton)
+EVT_BUTTON(ID_VDR_SETTINGS, VDRControl::OnSettingsButton)
+EVT_SLIDER(ID_VDR_SPEED_SLIDER, VDRControl::OnSpeedSliderUpdated)
+EVT_COMMAND_SCROLL_THUMBTRACK(ID_VDR_PROGRESS,
+                              VDRControl::OnProgressSliderUpdated)
+EVT_COMMAND_SCROLL_THUMBRELEASE(ID_VDR_PROGRESS,
+                                VDRControl::OnProgressSliderEndDrag)
+END_EVENT_TABLE()
+
+bool VDRControl::LoadFile(wxString currentFile) {
+  bool status = true;
+  wxString error;
+  UpdatePlaybackStatus(_("Stopped"));
+  UpdateNetworkStatus(wxEmptyString);
+  if (m_pvdr->LoadFile(currentFile, &error)) {
+    bool hasValidTimestamps;
+    wxString error;
+    bool success = m_pvdr->ScanFileTimestamps(hasValidTimestamps, error);
+    UpdateFileLabel(currentFile);
+    if (!success) {
+      UpdateFileStatus(error);
+      status = false;
+    } else {
+      UpdateFileStatus(_("File loaded successfully"));
+    }
+    m_progressSlider->SetValue(0);
+    UpdateControls();
+  } else {
+    // If loading fails, clear the saved filename
+    m_pvdr->ClearInputFile();
+    UpdateFileLabel(wxEmptyString);
+    UpdateFileStatus(error);
+    UpdateControls();
+    status = false;
+  }
+  return status;
+}
+
+VDRControl::VDRControl(wxWindow* parent, wxWindowID id, vdr_pi* vdr)
+    : wxWindow(parent, id, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE,
+               _T("VDR Control")),
+      m_pvdr(vdr),
+      m_isDragging(false),
+      m_wasPlayingBeforeDrag(false) {
+  wxColour cl;
+  GetGlobalColor(_T("DILG1"), &cl);
+  SetBackgroundColour(cl);
+
+  CreateControls();
+
+  // Check if there's already a file loaded from config
+  wxString currentFile = m_pvdr->GetInputFile();
+  if (!currentFile.IsEmpty()) {
+    // Try to load the file
+    LoadFile(currentFile);
+  } else {
+    UpdateFileStatus(_("No file loaded"));
+  }
+  UpdatePlaybackStatus(_("Stopped"));
+}
+
+void VDRControl::CreateControls() {
+  // Main vertical sizer
+  wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
+
+  wxFont* baseFont = GetOCPNScaledFont_PlugIn("Dialog", 0);
+  SetFont(*baseFont);
+  wxFont* buttonFont = FindOrCreateFont_PlugIn(
+      baseFont->GetPointSize() * GetContentScaleFactor(), baseFont->GetFamily(),
+      baseFont->GetStyle(), baseFont->GetWeight());
+  // Calculate button dimensions based on font height
+  int fontHeight = buttonFont->GetPointSize();
+  int buttonSize = fontHeight * 1.2;  // Adjust multiplier as needed
+  // Ensure minimum size of 32 pixels for touch usability
+  buttonSize = std::max(buttonSize, 32);
+#ifdef __WXQT__
+  // A simple way to get touch-compatible tool size
+  wxRect tbRect = GetMasterToolbarRect();
+  buttonSize = std::max(buttonSize, tbRect.width / 2);
+#endif
+  wxSize buttonDimension(buttonSize, buttonSize);
+
+  // File information section
+  wxBoxSizer* fileSizer = new wxBoxSizer(wxHORIZONTAL);
+
+  // Settings button
+  m_settingsBtn =
+      new wxButton(this, ID_VDR_SETTINGS, wxString::FromUTF8("⚙️"),
+                   wxDefaultPosition, buttonDimension, wxBU_EXACTFIT);
+  m_settingsBtn->SetFont(*buttonFont);
+  m_settingsBtn->SetMinSize(buttonDimension);
+  m_settingsBtn->SetMaxSize(buttonDimension);
+  m_settingsBtn->SetToolTip(_("Settings"));
+  fileSizer->Add(m_settingsBtn, 0, wxALL, 2);
+
+  // Load button
+  m_loadBtn = new wxButton(this, ID_VDR_LOAD, wxString::FromUTF8("📂"),
+                           wxDefaultPosition, buttonDimension, wxBU_EXACTFIT);
+  m_loadBtn->SetFont(*buttonFont);
+  m_loadBtn->SetMinSize(buttonDimension);
+  m_loadBtn->SetMaxSize(buttonDimension);
+  m_loadBtn->SetToolTip(_("Load VDR File"));
+  fileSizer->Add(m_loadBtn, 0, wxALL, 2);
+
+  m_fileLabel =
+      new wxStaticText(this, wxID_ANY, _("No file loaded"), wxDefaultPosition,
+                       wxDefaultSize, wxST_ELLIPSIZE_START);
+  fileSizer->Add(m_fileLabel, 1, wxALL | wxALIGN_CENTER_VERTICAL, 2);
+
+  mainSizer->Add(fileSizer, 0, wxALL, 4);
+
+  // Play controls and progress in one row
+  wxBoxSizer* controlSizer = new wxBoxSizer(wxHORIZONTAL);
+
+  // Play button setup
+  m_playBtnTooltip = _("Start Playback");
+  m_pauseBtnTooltip = _("Pause Playback");
+  m_stopBtnTooltip = _("End of File");
+
+  m_playPauseBtn =
+      new wxButton(this, ID_VDR_PLAY_PAUSE, wxString::FromUTF8("▶"),
+                   wxDefaultPosition, buttonDimension, wxBU_EXACTFIT);
+  m_playPauseBtn->SetFont(*buttonFont);
+  m_playPauseBtn->SetMinSize(buttonDimension);
+  m_playPauseBtn->SetMaxSize(buttonDimension);
+  m_playPauseBtn->SetToolTip(m_playBtnTooltip);
+  controlSizer->Add(m_playPauseBtn, 0, wxALL, 3);
+
+  // Progress slider in the same row as play button
+  m_progressSlider =
+      new wxSlider(this, ID_VDR_PROGRESS, 0, 0, 1000, wxDefaultPosition,
+                   wxDefaultSize, wxSL_HORIZONTAL | wxSL_BOTTOM);
+  controlSizer->Add(m_progressSlider, 1, wxALIGN_CENTER_VERTICAL, 0);
+  mainSizer->Add(controlSizer, 0, wxEXPAND | wxALL, 4);
+
+  // Time label
+  m_timeLabel = new wxStaticText(this, wxID_ANY, _("Date and Time: --"),
+                                 wxDefaultPosition, wxSize(200, -1));
+  mainSizer->Add(m_timeLabel, 0, wxEXPAND | wxALL, 4);
+
+  // Speed control
+  wxBoxSizer* speedSizer = new wxBoxSizer(wxHORIZONTAL);
+  speedSizer->Add(new wxStaticText(this, wxID_ANY, _("Speed:")), 0,
+                  wxALIGN_CENTER_VERTICAL | wxRIGHT, 3);
+  m_speedSlider =
+      new wxSlider(this, wxID_ANY, 1, 1, 1000, wxDefaultPosition, wxDefaultSize,
+                   wxSL_HORIZONTAL | wxSL_VALUE_LABEL);
+  speedSizer->Add(m_speedSlider, 1, wxEXPAND | wxALIGN_CENTER_VERTICAL, 0);
+  mainSizer->Add(speedSizer, 0, wxEXPAND | wxALL, 4);
+
+  // Add status panel
+  wxStaticBox* statusBox = new wxStaticBox(this, wxID_ANY, _("Status"));
+  wxStaticBoxSizer* statusSizer = new wxStaticBoxSizer(statusBox, wxVERTICAL);
+
+  // File status
+  wxBoxSizer* fileStatusSizer = new wxBoxSizer(wxHORIZONTAL);
+  fileStatusSizer->Add(new wxStaticText(this, wxID_ANY, _("File: ")), 0,
+                       wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+  m_fileStatusLabel = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  fileStatusSizer->Add(m_fileStatusLabel, 1, wxALIGN_CENTER_VERTICAL);
+  statusSizer->Add(fileStatusSizer, 0, wxEXPAND | wxALL, 5);
+
+  // Network status
+  wxBoxSizer* networkStatusSizer = new wxBoxSizer(wxHORIZONTAL);
+  networkStatusSizer->Add(new wxStaticText(this, wxID_ANY, _("Network: ")), 0,
+                          wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+  m_networkStatusLabel = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  networkStatusSizer->Add(m_networkStatusLabel, 1, wxALIGN_CENTER_VERTICAL);
+  statusSizer->Add(networkStatusSizer, 0, wxEXPAND | wxALL, 5);
+
+  // Playback status
+  wxBoxSizer* playbackStatusSizer = new wxBoxSizer(wxHORIZONTAL);
+  playbackStatusSizer->Add(new wxStaticText(this, wxID_ANY, _("Playback: ")), 0,
+                           wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+  m_playbackStatusLabel = new wxStaticText(this, wxID_ANY, wxEmptyString);
+  playbackStatusSizer->Add(m_playbackStatusLabel, 1, wxALIGN_CENTER_VERTICAL);
+  statusSizer->Add(playbackStatusSizer, 0, wxEXPAND | wxALL, 5);
+
+  mainSizer->Add(statusSizer, 0, wxEXPAND | wxALL, 5);
+
+  SetSizer(mainSizer);
+  wxClientDC dc(m_timeLabel);
+  wxSize textExtent = dc.GetTextExtent(_("Date and Time: YYYY-MM-DD HH:MM:SS"));
+  int minWidth = std::min(300, textExtent.GetWidth() + 20);  // 20px padding
+  mainSizer->SetMinSize(wxSize(minWidth, -1));
+  Layout();
+  mainSizer->Fit(this);
+
+  // Initial state
+  UpdateControls();
+}
+
+void VDRControl::SetSpeedMultiplier(int value) {
+  value = std::max(value, m_speedSlider->GetMin());
+  value = std::min(value, m_speedSlider->GetMax());
+  m_speedSlider->SetValue(value);
+}
+
+void VDRControl::UpdateTimeLabel() {
+  if (m_pvdr->GetCurrentTimestamp().IsValid()) {
+    wxString timeStr =
+        m_pvdr->GetCurrentTimestamp().ToUTC().Format("%Y-%m-%d %H:%M:%S UTC");
+    m_timeLabel->SetLabel("Date and Time: " + timeStr);
+  } else {
+    m_timeLabel->SetLabel(_("Date and Time: --"));
+  }
+}
+
+void VDRControl::OnLoadButton(wxCommandEvent& event) {
+  // Stop any current playback
+  if (m_pvdr->IsPlaying()) {
+    StopPlayback();
+  }
+
+  wxString file;
+  wxString init_directory = wxEmptyString;
+#ifdef __WXQT__
+  init_directory = *GetpPrivateApplicationDataLocation();
+#endif
+
+  int response = PlatformFileSelectorDialog(GetOCPNCanvasWindow(), &file,
+                                            _("Select Playback File"),
+                                            init_directory, _T(""), _T("*.*"));
+
+  if (response == wxID_OK) {
+    LoadFile(file);
+  }
+}
+
+void VDRControl::OnProgressSliderUpdated(wxScrollEvent& event) {
+  if (!m_isDragging) {
+    m_isDragging = true;
+    m_wasPlayingBeforeDrag = m_pvdr->IsPlaying();
+    if (m_wasPlayingBeforeDrag) {
+      PausePlayback();
+    }
+  }
+  if (m_pvdr->GetFirstTimestamp().IsValid() &&
+      m_pvdr->GetLastTimestamp().IsValid()) {
+    // Update time display while dragging but don't seek yet
+    double fraction = m_progressSlider->GetValue() / 1000.0;
+    wxTimeSpan totalSpan =
+        m_pvdr->GetLastTimestamp() - m_pvdr->GetFirstTimestamp();
+    wxTimeSpan currentSpan =
+        wxTimeSpan::Seconds((totalSpan.GetSeconds().ToDouble() * fraction));
+    m_pvdr->SetCurrentTimestamp(m_pvdr->GetFirstTimestamp() + currentSpan);
+    UpdateTimeLabel();
+  }
+  event.Skip();
+}
+
+void VDRControl::OnProgressSliderEndDrag(wxScrollEvent& event) {
+  double fraction = m_progressSlider->GetValue() / 1000.0;
+  m_pvdr->SeekToFraction(fraction);
+  // Reset the end-of-file state when user drags the slider, the button should
+  // change to "play" state.
+  m_pvdr->ResetEndOfFile();
+  if (m_wasPlayingBeforeDrag) {
+    StartPlayback();
+  }
+  m_isDragging = false;
+  UpdateControls();
+  event.Skip();
+}
+
+void VDRControl::UpdateControls() {
+  bool hasFile = !m_pvdr->GetInputFile().IsEmpty();
+  bool isRecording = m_pvdr->IsRecording();
+  bool isPlaying = m_pvdr->IsPlaying();
+  bool isAtEnd = m_pvdr->IsAtFileEnd();
+
+  // Update the play/pause/stop button appearance
+  if (isAtEnd) {
+    m_playPauseBtn->SetLabel(wxString::FromUTF8("⏹"));
+    m_playPauseBtn->SetToolTip(m_stopBtnTooltip);
+    m_progressSlider->SetValue(1000);
+    UpdateFileStatus(_("End of file"));
+  } else {
+    m_playPauseBtn->SetLabel(isPlaying ? wxString::FromUTF8("⏸")
+                                       : wxString::FromUTF8("▶"));
+    m_playPauseBtn->SetToolTip(isPlaying ? m_pauseBtnTooltip
+                                         : m_playBtnTooltip);
+  }
+
+  // Enable/disable controls based on state
+  m_loadBtn->Enable(!isRecording && !isPlaying);
+  m_playPauseBtn->Enable(hasFile && !isRecording);
+  m_settingsBtn->Enable(!isPlaying && !isRecording);
+  m_progressSlider->Enable(hasFile && !isRecording);
+
+  // Update toolbar state
+  m_pvdr->SetToolbarToolStatus(m_pvdr->GetPlayToolbarItemId(), isPlaying);
+
+  // Update time display
+  if (hasFile && m_pvdr->GetCurrentTimestamp().IsValid()) {
+    wxString timeStr =
+        m_pvdr->GetCurrentTimestamp().ToUTC().Format("%Y-%m-%d %H:%M:%S UTC");
+    m_timeLabel->SetLabel("Date and Time: " + timeStr);
+  } else {
+    m_timeLabel->SetLabel(_("Date and Time: --"));
+  }
+  Layout();
+}
+
+void VDRControl::UpdateFileLabel(const wxString& filename) {
+  if (filename.IsEmpty()) {
+    m_fileLabel->SetLabel(_("No file loaded"));
+  } else {
+    wxFileName fn(filename);
+    m_fileLabel->SetLabel(fn.GetFullName());
+  }
+  m_fileLabel->GetParent()->Layout();
+}
+
+void VDRControl::StartPlayback() {
+  m_pvdr->StartPlayback();
+  UpdatePlaybackStatus(_("Playing"));
+}
+
+void VDRControl::PausePlayback() {
+  m_pvdr->PausePlayback();
+  UpdatePlaybackStatus(_("Paused"));
+}
+
+void VDRControl::StopPlayback() {
+  m_pvdr->StopPlayback();
+  UpdatePlaybackStatus(_("Stopped"));
+}
+
+void VDRControl::OnPlayPauseButton(wxCommandEvent& event) {
+  if (!m_pvdr->IsPlaying()) {
+    if (m_pvdr->GetInputFile().IsEmpty()) {
+      UpdateFileStatus(_("No file selected"));
+      return;
+    }
+
+    // If we're at the end, restart from beginning
+    if (m_pvdr->IsAtFileEnd()) {
+      StopPlayback();
+    }
+    StartPlayback();
+  } else {
+    PausePlayback();
+  }
+  UpdateControls();
+}
+
+void VDRControl::OnDataFormatRadioButton(wxCommandEvent& event) {
+  // Radio button state is tracked by wx, we just need to handle any
+  // format-specific UI updates here if needed in the future
+}
+
+void VDRControl::OnSettingsButton(wxCommandEvent& event) {
+  m_pvdr->ShowPreferencesDialogNative(this);
+  event.Skip();
+}
+
+void VDRControl::OnSpeedSliderUpdated(wxCommandEvent& event) {
+  if (m_pvdr->IsPlaying()) {
+    m_pvdr->AdjustPlaybackBaseTime();
+  }
+}
+
+void VDRControl::SetProgress(double fraction) {
+  // Update slider position (0-1000 range)
+  int sliderPos = wxRound(fraction * 1000);
+  m_progressSlider->SetValue(sliderPos);
+
+  if (m_pvdr->GetFirstTimestamp().IsValid() &&
+      m_pvdr->GetLastTimestamp().IsValid()) {
+    // Calculate and set current timestamp based on the fraction
+    wxTimeSpan totalSpan =
+        m_pvdr->GetLastTimestamp() - m_pvdr->GetFirstTimestamp();
+    wxTimeSpan currentSpan =
+        wxTimeSpan::Seconds((totalSpan.GetSeconds().ToDouble() * fraction));
+    m_pvdr->SetCurrentTimestamp(m_pvdr->GetFirstTimestamp() + currentSpan);
+
+    // Update time display
+    UpdateTimeLabel();
+  }
+}
+
+void VDRControl::SetColorScheme(PI_ColorScheme cs) {
+  wxColour cl;
+  GetGlobalColor(_T("DILG1"), &cl);
+  SetBackgroundColour(cl);
+
+  Refresh(false);
+}
+
+void VDRControl::UpdateFileStatus(const wxString& status) {
+  if (m_fileStatusLabel) {
+    m_fileStatusLabel->SetLabel(status);
+  }
+}
+
+void VDRControl::UpdateNetworkStatus(const wxString& status) {
+  if (m_networkStatusLabel) {
+    m_networkStatusLabel->SetLabel(status);
+  }
+}
+
+void VDRControl::UpdatePlaybackStatus(const wxString& status) {
+  if (m_playbackStatusLabel) {
+    m_playbackStatusLabel->SetLabel(status);
+  }
+}

--- a/src/vdr_pi_control.h
+++ b/src/vdr_pi_control.h
@@ -1,0 +1,179 @@
+/***************************************************************************
+ *   Copyright (C) 2024 by OpenCPN development team                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ **************************************************************************/
+
+#ifndef _VDR_PI_CONTROL_H_
+#define _VDR_PI_CONTROL_H_
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
+#include "ocpn_plugin.h"
+
+class vdr_pi;
+
+/**
+ * UI control panel for VDR playback functionality.
+ *
+ * Provides controls for loading VDR files, starting/pausing playback,
+ * adjusting playback speed, and monitoring playback progress.
+ */
+class VDRControl : public wxWindow {
+public:
+  /**
+   * Create a new VDR control panel.
+   *
+   * Initializes UI elements and loads any previously configured VDR file.
+   * @param pparent Parent window for the control panel
+   * @param id Window identifier
+   * @param vdr Owner VDR plugin instance
+   */
+  VDRControl(wxWindow* pparent, wxWindowID id, vdr_pi* vdr);
+
+  /**
+   * Update UI elements for color scheme changes.
+   * @param cs New color scheme to apply
+   */
+  void SetColorScheme(PI_ColorScheme cs);
+
+  /**
+   * Update progress indication for playback position.
+   * @param fraction Current position as fraction between 0-1
+   */
+  void SetProgress(double fraction);
+
+  /** Update state of UI controls based on playback status. */
+  void UpdateControls();
+
+  /**
+   * Update displayed filename in UI.
+   * @param filename Path of currently loaded file
+   */
+  void UpdateFileLabel(const wxString& filename);
+
+  /** Update displayed timestamp in UI based on current playback position. */
+  void UpdateTimeLabel();
+
+  /** Get current playback speed multiplier setting. */
+  int GetSpeedMultiplier() const { return m_speedSlider->GetValue(); }
+
+  /** Set the speed multiplier settting. */
+  void SetSpeedMultiplier(int value);
+
+  /**
+   * Update file status label with new message.
+   */
+  void UpdateFileStatus(const wxString& status);
+  /**
+   * Update network status label with new message.
+   */
+  void UpdateNetworkStatus(const wxString& status);
+  /**
+   * Update playback status label with new message.
+   */
+  void UpdatePlaybackStatus(const wxString& status);
+
+private:
+  /** Create and layout UI controls. */
+  void CreateControls();
+
+  /**
+   * Handle file load button clicks.
+   *
+   * Shows file selection dialog and loads selected VDR file.
+   */
+  void OnLoadButton(wxCommandEvent& event);
+
+  /**
+   * Handle play/pause button clicks.
+   *
+   * Toggles between playback and paused states.
+   */
+  void OnPlayPauseButton(wxCommandEvent& event);
+
+  /**
+   * Handle playback speed adjustment.
+   *
+   * Updates playback timing when speed multiplier changes.
+   */
+  void OnSpeedSliderUpdated(wxCommandEvent& event);
+
+  /**
+   * Handle progress slider dragging.
+   *
+   * Temporarily pauses playback while user drags position slider.
+   */
+  void OnProgressSliderUpdated(wxScrollEvent& even);
+
+  /**
+   * Handle progress slider release.
+   *
+   * Seeks to new position and resumes playback if previously playing.
+   */
+  void OnProgressSliderEndDrag(wxScrollEvent& event);
+
+  /** Handle data format selection changes. */
+  void OnDataFormatRadioButton(wxCommandEvent& event);
+
+  /** Handle left-click on Settings button. */
+  void OnSettingsButton(wxCommandEvent& event);
+
+  /**
+   * Start playback of loaded VDR file and update status.
+   */
+  void StartPlayback();
+
+  /**
+   * Pause playback of loaded VDR file and update status.
+   */
+  void PausePlayback();
+
+  /**
+   * Stop playback of loaded VDR file and update status.
+   */
+  void StopPlayback();
+
+  bool LoadFile(wxString currentFile);
+
+  wxButton* m_loadBtn;         //!< Button to load VDR file
+  wxButton* m_settingsBtn;     //!< Button to open settings dialog
+  wxButton* m_playPauseBtn;    //!< Toggle button for play/pause
+  wxString m_playBtnTooltip;   //!< Tooltip text for play state
+  wxString m_pauseBtnTooltip;  //!< Tooltip text for pause state
+  wxString m_stopBtnTooltip;   //!< Tooltip text for stop state
+
+  wxSlider* m_speedSlider;     //!< Slider control for playback speed
+  wxSlider* m_progressSlider;  //!< Slider control for playback position
+  wxStaticText* m_fileLabel;   //!< Label showing current filename
+  wxStaticText* m_timeLabel;   //!< Label showing current timestamp
+  vdr_pi* m_pvdr;              //!< Owner plugin instance
+
+  bool m_isDragging;            //!< Flag indicating progress slider drag
+  bool m_wasPlayingBeforeDrag;  //!< Playback state before drag started
+
+  // Status labels
+  wxStaticText* m_fileStatusLabel;      //!< Label showing file status.
+  wxStaticText* m_networkStatusLabel;   //!< Label showing network status.
+  wxStaticText* m_playbackStatusLabel;  //!< Label showing playback status.
+
+  DECLARE_EVENT_TABLE()
+};
+
+#endif  // _VDR_PI_CONTROL_H_

--- a/src/vdr_pi_prefs.cpp
+++ b/src/vdr_pi_prefs.cpp
@@ -22,6 +22,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  **************************************************************************/
 
+#include "vdr_pi_prefs_net.h"
 #include "vdr_pi_prefs.h"
 
 enum {
@@ -31,7 +32,9 @@ enum {
   ID_USE_SPEED_THRESHOLD_CHECK,  // ID for speed threshold checkbox
   ID_NMEA0183_CHECK,
   ID_NMEA2000_CHECK,
-  ID_SIGNALK_CHECK
+  ID_SIGNALK_CHECK,
+  ID_NMEA0183_NETWORK_RADIO,
+  ID_NMEA0183_INTERNAL_RADIO
 };
 
 BEGIN_EVENT_TABLE(VDRPrefsDialog, wxDialog)
@@ -41,6 +44,12 @@ EVT_CHECKBOX(ID_VDR_LOG_ROTATE_CHECK, VDRPrefsDialog::OnLogRotateCheck)
 EVT_CHECKBOX(ID_VDR_AUTO_RECORD_CHECK, VDRPrefsDialog::OnAutoRecordCheck)
 EVT_CHECKBOX(ID_USE_SPEED_THRESHOLD_CHECK,
              VDRPrefsDialog::OnUseSpeedThresholdCheck)
+EVT_CHECKBOX(ID_NMEA0183_CHECK, VDRPrefsDialog::OnProtocolCheck)
+EVT_CHECKBOX(ID_NMEA2000_CHECK, VDRPrefsDialog::OnProtocolCheck)
+EVT_RADIOBUTTON(ID_NMEA0183_NETWORK_RADIO,
+                VDRPrefsDialog::OnNMEA0183ReplayModeChanged)
+EVT_RADIOBUTTON(ID_NMEA0183_INTERNAL_RADIO,
+                VDRPrefsDialog::OnNMEA0183ReplayModeChanged)
 END_EVENT_TABLE()
 
 VDRPrefsDialog::VDRPrefsDialog(wxWindow* parent, wxWindowID id,
@@ -67,6 +76,10 @@ VDRPrefsDialog::VDRPrefsDialog(wxWindow* parent, wxWindowID id,
   Centre();
 }
 
+void VDRPrefsDialog::OnProtocolCheck(wxCommandEvent& event) {
+  UpdateControlStates();
+}
+
 void VDRPrefsDialog::UpdateControlStates() {
   // File rotation controls
   m_logRotateIntervalCtrl->Enable(m_logRotateCheck->GetValue());
@@ -86,22 +99,51 @@ void VDRPrefsDialog::CreateControls() {
   wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
   SetSizer(mainSizer);
 
+  // Create notebook for tabs
+  wxNotebook* notebook;
+  notebook = new wxNotebook(this, wxID_ANY);
+  mainSizer->Add(notebook, 1, wxEXPAND | wxALL, 5);
+
+  // Add tabs
+  wxPanel* recordingTab = CreateRecordingTab(notebook);
+  wxPanel* replayTab = CreateReplayTab(notebook);
+
+  notebook->AddPage(recordingTab, _("Recording"));
+  notebook->AddPage(replayTab, _("Replay"));
+
+  // Standard dialog buttons
+  wxStdDialogButtonSizer* buttonSizer = new wxStdDialogButtonSizer();
+  buttonSizer->AddButton(new wxButton(this, wxID_OK));
+  buttonSizer->AddButton(new wxButton(this, wxID_CANCEL));
+  buttonSizer->Realize();
+  mainSizer->Add(buttonSizer, 0, wxEXPAND | wxALL, 5);
+
+  mainSizer->SetSizeHints(this);
+
+  // Set initial control states
+  UpdateControlStates();
+}
+
+wxPanel* VDRPrefsDialog::CreateRecordingTab(wxWindow* parent) {
+  wxPanel* panel = new wxPanel(parent);
+  wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
+
   // Protocol selection section
   wxStaticBox* protocolBox =
-      new wxStaticBox(this, wxID_ANY, _("Recording Protocols"));
+      new wxStaticBox(panel, wxID_ANY, _("Recording Protocols"));
   wxStaticBoxSizer* protocolSizer =
       new wxStaticBoxSizer(protocolBox, wxVERTICAL);
 
-  m_nmea0183Check = new wxCheckBox(this, ID_NMEA0183_CHECK, _("NMEA 0183"));
+  m_nmea0183Check = new wxCheckBox(panel, ID_NMEA0183_CHECK, _("NMEA 0183"));
   m_nmea0183Check->SetValue(m_protocols.nmea0183);
   protocolSizer->Add(m_nmea0183Check, 0, wxALL, 5);
 
-  m_nmea2000Check = new wxCheckBox(this, ID_NMEA2000_CHECK, _("NMEA 2000"));
+  m_nmea2000Check = new wxCheckBox(panel, ID_NMEA2000_CHECK, _("NMEA 2000"));
   m_nmea2000Check->SetValue(m_protocols.nmea2000);
   protocolSizer->Add(m_nmea2000Check, 0, wxALL, 5);
 
 #if 0
-  m_signalKCheck = new wxCheckBox(this, ID_SIGNALK_CHECK, _("Signal K"));
+  m_signalKCheck = new wxCheckBox(panel, ID_SIGNALK_CHECK, _("Signal K"));
   m_signalKCheck->SetValue(m_protocols.signalK);
   protocolSizer->Add(m_signalKCheck, 0, wxALL, 5);
 #endif
@@ -110,12 +152,12 @@ void VDRPrefsDialog::CreateControls() {
 
   // Add format choice
   wxStaticBox* formatBox =
-      new wxStaticBox(this, wxID_ANY, _("Recording Format"));
+      new wxStaticBox(panel, wxID_ANY, _("Recording Format"));
   wxStaticBoxSizer* formatSizer = new wxStaticBoxSizer(formatBox, wxVERTICAL);
 
-  m_nmeaRadio = new wxRadioButton(this, wxID_ANY, _("Raw NMEA"),
+  m_nmeaRadio = new wxRadioButton(panel, wxID_ANY, _("Raw NMEA"),
                                   wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
-  m_csvRadio = new wxRadioButton(this, wxID_ANY, _("CSV with timestamps"));
+  m_csvRadio = new wxRadioButton(panel, wxID_ANY, _("CSV with timestamps"));
 
   formatSizer->Add(m_nmeaRadio, 0, wxALL, 5);
   formatSizer->Add(m_csvRadio, 0, wxALL, 5);
@@ -124,12 +166,12 @@ void VDRPrefsDialog::CreateControls() {
 
   // Add recording directory controls
   wxStaticBox* dirBox =
-      new wxStaticBox(this, wxID_ANY, _("Recording Directory"));
+      new wxStaticBox(panel, wxID_ANY, _("Recording Directory"));
   wxStaticBoxSizer* dirSizer = new wxStaticBoxSizer(dirBox, wxHORIZONTAL);
 
-  m_dirCtrl = new wxTextCtrl(this, wxID_ANY, m_recording_dir, wxDefaultPosition,
-                             wxDefaultSize, wxTE_READONLY);
-  m_dirButton = new wxButton(this, ID_VDR_DIR_BUTTON, _("Browse..."));
+  m_dirCtrl = new wxTextCtrl(panel, wxID_ANY, m_recording_dir,
+                             wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+  m_dirButton = new wxButton(panel, ID_VDR_DIR_BUTTON, _("Browse..."));
 
   dirSizer->Add(m_dirCtrl, 1, wxALL | wxEXPAND, 5);
   dirSizer->Add(m_dirButton, 0, wxALL | wxEXPAND, 5);
@@ -149,20 +191,20 @@ void VDRPrefsDialog::CreateControls() {
 
   // File management section.
   wxStaticBox* logBox =
-      new wxStaticBox(this, wxID_ANY, _("VDR File Management"));
+      new wxStaticBox(panel, wxID_ANY, _("VDR File Management"));
   wxStaticBoxSizer* logSizer = new wxStaticBoxSizer(logBox, wxVERTICAL);
 
-  m_logRotateCheck = new wxCheckBox(this, ID_VDR_LOG_ROTATE_CHECK,
+  m_logRotateCheck = new wxCheckBox(panel, ID_VDR_LOG_ROTATE_CHECK,
                                     _("Create new VDR file every:"));
   m_logRotateCheck->SetValue(m_log_rotate);
 
   wxBoxSizer* intervalSizer = new wxBoxSizer(wxHORIZONTAL);
   m_logRotateIntervalCtrl = new wxSpinCtrl(
-      this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+      panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize,
       wxSP_ARROW_KEYS, 1, 168, m_log_rotate_interval);
   intervalSizer->Add(m_logRotateIntervalCtrl, 0,
                      wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-  intervalSizer->Add(new wxStaticText(this, wxID_ANY, _("hours")), 0,
+  intervalSizer->Add(new wxStaticText(panel, wxID_ANY, _("hours")), 0,
                      wxALIGN_CENTER_VERTICAL);
 
   logSizer->Add(m_logRotateCheck, 0, wxALL, 5);
@@ -172,55 +214,98 @@ void VDRPrefsDialog::CreateControls() {
 
   // Auto-recording section
   wxStaticBox* autoBox =
-      new wxStaticBox(this, wxID_ANY, _("Automatic Recording"));
+      new wxStaticBox(panel, wxID_ANY, _("Automatic Recording"));
   wxStaticBoxSizer* autoSizer = new wxStaticBoxSizer(autoBox, wxVERTICAL);
 
   // Auto-start option
   m_autoStartRecordingCheck = new wxCheckBox(
-      this, ID_VDR_AUTO_RECORD_CHECK, _("Automatically start recording"));
+      panel, ID_VDR_AUTO_RECORD_CHECK, _("Automatically start recording"));
   m_autoStartRecordingCheck->SetValue(m_auto_start_recording);
   autoSizer->Add(m_autoStartRecordingCheck, 0, wxALL, 5);
 
   // Speed threshold option
   wxBoxSizer* speedSizer = new wxBoxSizer(wxHORIZONTAL);
   m_useSpeedThresholdCheck = new wxCheckBox(
-      this, ID_USE_SPEED_THRESHOLD_CHECK, _("When speed over ground exceeds"));
+      panel, ID_USE_SPEED_THRESHOLD_CHECK, _("When speed over ground exceeds"));
   m_useSpeedThresholdCheck->SetValue(m_use_speed_threshold);
   speedSizer->Add(m_useSpeedThresholdCheck, 0, wxALIGN_CENTER_VERTICAL);
 
   m_speedThresholdCtrl = new wxSpinCtrlDouble(
-      this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize,
+      panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize,
       wxSP_ARROW_KEYS, 0.0, 20.0, m_speed_threshold, 0.1);
   speedSizer->Add(m_speedThresholdCtrl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT,
                   5);
-  speedSizer->Add(new wxStaticText(this, wxID_ANY, _("knots")), 0,
+  speedSizer->Add(new wxStaticText(panel, wxID_ANY, _("knots")), 0,
                   wxALIGN_CENTER_VERTICAL);
   autoSizer->Add(speedSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
   // Pause delay control
   wxBoxSizer* delaySizer = new wxBoxSizer(wxHORIZONTAL);
-  delaySizer->Add(new wxStaticText(this, wxID_ANY, _("Pause recording after")),
+  delaySizer->Add(new wxStaticText(panel, wxID_ANY, _("Pause recording after")),
                   0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
   m_stopDelayCtrl =
-      new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition,
+      new wxSpinCtrl(panel, wxID_ANY, wxEmptyString, wxDefaultPosition,
                      wxDefaultSize, wxSP_ARROW_KEYS, 1, 60, m_stop_delay);
   delaySizer->Add(m_stopDelayCtrl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
   delaySizer->Add(
-      new wxStaticText(this, wxID_ANY, _("minutes below speed threshold")), 0,
+      new wxStaticText(panel, wxID_ANY, _("minutes below speed threshold")), 0,
       wxALIGN_CENTER_VERTICAL);
   autoSizer->Add(delaySizer, 0, wxLEFT | wxRIGHT | wxBOTTOM, 5);
   mainSizer->Add(autoSizer, 0, wxEXPAND | wxALL, 5);
 
-  // Standard dialog buttons
-  wxStdDialogButtonSizer* buttonSizer = new wxStdDialogButtonSizer();
-  buttonSizer->AddButton(new wxButton(this, wxID_OK));
-  buttonSizer->AddButton(new wxButton(this, wxID_CANCEL));
-  buttonSizer->Realize();
+  panel->SetSizer(mainSizer);
+  return panel;
+}
 
-  mainSizer->Add(buttonSizer, 0, wxEXPAND | wxALL, 5);
+wxPanel* VDRPrefsDialog::CreateReplayTab(wxWindow* parent) {
+  wxPanel* panel = new wxPanel(parent);
+  wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
 
-  // Set initial control states
-  UpdateControlStates();
+  // Add network panels for each protocol
+  // NMEA 0183 replay mode selection
+  wxStaticBox* nmea0183Box =
+      new wxStaticBox(panel, wxID_ANY, _("NMEA 0183 Replay Method"));
+  wxStaticBoxSizer* nmea0183Sizer =
+      new wxStaticBoxSizer(nmea0183Box, wxVERTICAL);
+
+  m_nmea0183InternalRadio = new wxRadioButton(
+      panel, ID_NMEA0183_INTERNAL_RADIO, _("Use internal API"),
+      wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+  m_nmea0183NetworkRadio = new wxRadioButton(
+      panel, ID_NMEA0183_NETWORK_RADIO, _("Use network connection (UDP/TCP)"));
+
+  m_nmea0183InternalRadio->SetValue(m_protocols.nmea0183ReplayMode ==
+                                    NMEA0183ReplayMode::INTERNAL_API);
+  m_nmea0183NetworkRadio->SetValue(m_protocols.nmea0183ReplayMode ==
+                                   NMEA0183ReplayMode::NETWORK);
+
+  nmea0183Sizer->Add(m_nmea0183InternalRadio, 0, wxALL, 5);
+  nmea0183Sizer->Add(m_nmea0183NetworkRadio, 0, wxALL, 5);
+  mainSizer->Add(nmea0183Sizer, 0, wxEXPAND | wxALL, 5);
+
+  // Network settings
+
+  // Add network panels for each protocol
+  m_nmea0183NetPanel = new ConnectionSettingsPanel(panel, _("NMEA 0183"),
+                                                   m_protocols.nmea0183Net);
+  mainSizer->Add(m_nmea0183NetPanel, 0, wxEXPAND | wxALL, 5);
+  // Enable/disable NMEA 0183 network panel based on replay mode
+  m_nmea0183NetPanel->Enable(m_protocols.nmea0183ReplayMode ==
+                             NMEA0183ReplayMode::NETWORK);
+
+  m_nmea2000NetPanel =
+      new ConnectionSettingsPanel(panel, _("NMEA 2000"), m_protocols.n2kNet);
+  mainSizer->Add(m_nmea2000NetPanel, 0, wxEXPAND | wxALL, 5);
+
+#if 0  // Signal K support disabled for now
+  m_signalKNetPanel = new ConnectionSettingsPanel(panel, _("Signal K"),
+                                              m_protocols.signalKNet);
+  mainSizer->Add(m_signalKNetPanel, 0, wxEXPAND | wxALL, 5);
+#endif
+
+  panel->SetSizer(mainSizer);
+
+  return panel;
 }
 
 void VDRPrefsDialog::OnOK(wxCommandEvent& event) {
@@ -233,11 +318,23 @@ void VDRPrefsDialog::OnOK(wxCommandEvent& event) {
   m_speed_threshold = m_speedThresholdCtrl->GetValue();
   m_stop_delay = m_stopDelayCtrl->GetValue();
 
+  // Protocol settings
   m_protocols.nmea0183 = m_nmea0183Check->GetValue();
   m_protocols.nmea2000 = m_nmea2000Check->GetValue();
 #if 0
   m_protocols.signalK = m_signalKCheck->GetValue();
 #endif
+
+  // Network settings
+  m_protocols.nmea0183Net = m_nmea0183NetPanel->GetSettings();
+  m_protocols.n2kNet = m_nmea2000NetPanel->GetSettings();
+#if 0
+  m_protocols.signalKNet = m_signalKNetPanel->GetSettings();
+#endif
+  m_protocols.nmea0183ReplayMode = m_nmea0183InternalRadio->GetValue()
+                                       ? NMEA0183ReplayMode::INTERNAL_API
+                                       : NMEA0183ReplayMode::NETWORK;
+
   event.Skip();
 }
 
@@ -261,4 +358,8 @@ void VDRPrefsDialog::OnAutoRecordCheck(wxCommandEvent& event) {
 
 void VDRPrefsDialog::OnUseSpeedThresholdCheck(wxCommandEvent& event) {
   UpdateControlStates();
+}
+
+void VDRPrefsDialog::OnNMEA0183ReplayModeChanged(wxCommandEvent& event) {
+  m_nmea0183NetPanel->Enable(event.GetId() == ID_NMEA0183_NETWORK_RADIO);
 }

--- a/src/vdr_pi_prefs.h
+++ b/src/vdr_pi_prefs.h
@@ -34,6 +34,7 @@
 #include <wx/spinctrl.h>
 
 #include "vdr_pi.h"
+#include "vdr_pi_prefs_net.h"
 
 /**
  * Preferences dialog for configuring VDR settings.
@@ -108,12 +109,24 @@ private:
   /** Handle speed threshold checkbox changes. */
   void OnUseSpeedThresholdCheck(wxCommandEvent& event);
 
+  /** Handle protocol checkbox changes. */
+  void OnProtocolCheck(wxCommandEvent& event);
+
+  void OnNMEA0183ReplayModeChanged(wxCommandEvent& event);
+
   /** Update enabled state of dependent controls. */
   void UpdateControlStates();
 
   /** Create and layout dialog controls. */
   void CreateControls();
 
+  /** Create controls for recording settings tab */
+  wxPanel* CreateRecordingTab(wxWindow* parent);
+
+  /** Create controls for replay settings tab */
+  wxPanel* CreateReplayTab(wxWindow* parent);
+
+  // Recording tab controls
   wxRadioButton* m_nmeaRadio;           //!< Raw NMEA format selection
   wxRadioButton* m_csvRadio;            //!< CSV format selection
   wxTextCtrl* m_dirCtrl;                //!< Recording directory display
@@ -132,6 +145,18 @@ private:
   wxCheckBox* m_nmea2000Check;  //!< Enable NMEA 2000 recording
 #if 0
    wxCheckBox* m_signalKCheck;      //!< Enable Signal K recording
+#endif
+
+  // Replay tab controls
+  // NMEA 0183 replay mode
+  wxRadioButton* m_nmea0183NetworkRadio;
+  wxRadioButton* m_nmea0183InternalRadio;
+
+  // Network selection
+  ConnectionSettingsPanel* m_nmea0183NetPanel;
+  ConnectionSettingsPanel* m_nmea2000NetPanel;
+#if 0
+  ConnectionSettingsPanel* m_signalKNetPanel;
 #endif
 
   VDRDataFormat m_format;       //!< Selected data format

--- a/src/vdr_pi_prefs_net.cpp
+++ b/src/vdr_pi_prefs_net.cpp
@@ -1,0 +1,94 @@
+/***************************************************************************
+ *   Copyright (C) 2024 by OpenCPN development team                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ **************************************************************************/
+
+#include "vdr_pi_prefs.h"
+
+BEGIN_EVENT_TABLE(ConnectionSettingsPanel, wxPanel)
+EVT_CHECKBOX(wxID_ANY, ConnectionSettingsPanel::OnEnableNetwork)
+END_EVENT_TABLE()
+
+ConnectionSettingsPanel::ConnectionSettingsPanel(
+    wxWindow* parent, const wxString& title, const ConnectionSettings& settings)
+    : wxPanel(parent) {
+  wxStaticBox* box = new wxStaticBox(this, wxID_ANY, title);
+  wxStaticBoxSizer* sizer = new wxStaticBoxSizer(box, wxVERTICAL);
+
+  // Enable checkbox
+  m_enableCheck = new wxCheckBox(this, wxID_ANY, _("Enable network output"));
+  m_enableCheck->SetValue(settings.enabled);
+  m_enableCheck->Bind(wxEVT_CHECKBOX, &ConnectionSettingsPanel::OnEnableNetwork,
+                      this);
+  sizer->Add(m_enableCheck, 0, wxALL, 5);
+
+  // Protocol selection
+  wxBoxSizer* protocolSizer = new wxBoxSizer(wxHORIZONTAL);
+  protocolSizer->Add(new wxStaticText(this, wxID_ANY, _("Protocol:")), 0,
+                     wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+
+  m_tcpRadio = new wxRadioButton(this, wxID_ANY, _("TCP"), wxDefaultPosition,
+                                 wxDefaultSize, wxRB_GROUP);
+  m_udpRadio = new wxRadioButton(this, wxID_ANY, _("UDP"));
+  m_tcpRadio->SetValue(settings.useTCP);
+  m_udpRadio->SetValue(!settings.useTCP);
+
+  protocolSizer->Add(m_tcpRadio, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+  protocolSizer->Add(m_udpRadio, 0, wxALIGN_CENTER_VERTICAL);
+  sizer->Add(protocolSizer, 0, wxALL, 5);
+
+  // Port number
+  wxBoxSizer* portSizer = new wxBoxSizer(wxHORIZONTAL);
+  portSizer->Add(new wxStaticText(this, wxID_ANY, _("Port:")), 0,
+                 wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+
+  m_portCtrl = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition,
+                              wxDefaultSize, wxSP_ARROW_KEYS, 1024, 65535,
+                              settings.port);
+  portSizer->Add(m_portCtrl, 0, wxALIGN_CENTER_VERTICAL);
+  sizer->Add(portSizer, 0, wxALL, 5);
+
+  SetSizer(sizer);
+  UpdateControlStates();
+}
+
+ConnectionSettings ConnectionSettingsPanel::GetSettings() const {
+  ConnectionSettings settings;
+  settings.enabled = m_enableCheck->GetValue();
+  settings.useTCP = m_tcpRadio->GetValue();
+  settings.port = m_portCtrl->GetValue();
+  return settings;
+}
+
+void ConnectionSettingsPanel::SetSettings(const ConnectionSettings& settings) {
+  m_enableCheck->SetValue(settings.enabled);
+  m_tcpRadio->SetValue(settings.useTCP);
+  m_udpRadio->SetValue(!settings.useTCP);
+  m_portCtrl->SetValue(settings.port);
+  UpdateControlStates();
+}
+
+void ConnectionSettingsPanel::OnEnableNetwork(wxCommandEvent& event) {
+  UpdateControlStates();
+}
+
+void ConnectionSettingsPanel::UpdateControlStates() {
+  bool enabled = m_enableCheck->GetValue();
+  m_tcpRadio->Enable(enabled);
+  m_udpRadio->Enable(enabled);
+  m_portCtrl->Enable(enabled);
+}

--- a/src/vdr_pi_prefs_net.h
+++ b/src/vdr_pi_prefs_net.h
@@ -1,0 +1,67 @@
+/***************************************************************************
+ *   Copyright (C) 2024 by OpenCPN development team                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ **************************************************************************/
+
+#ifndef _VDR_PI_PREFS_NET_H_
+#define _VDR_PI_PREFS_NET_H_
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
+#include <wx/dialog.h>
+#include <wx/spinctrl.h>
+
+struct ConnectionSettings;
+
+/** UI component for connection settings */
+class ConnectionSettingsPanel : public wxPanel {
+public:
+  /**
+   * Create connection settings panel.
+   *
+   * @param parent Parent window
+   * @param title Title for the static box
+   * @param settings Initial connection settings
+   */
+  ConnectionSettingsPanel(wxWindow* parent, const wxString& title,
+                          const ConnectionSettings& settings);
+
+  /** Get current connection settings from controls */
+  ConnectionSettings GetSettings() const;
+
+  /** Update controls with new settings */
+  void SetSettings(const ConnectionSettings& settings);
+
+private:
+  /** Handle network enable checkbox */
+  void OnEnableNetwork(wxCommandEvent& event);
+
+  /** Update enabled state of controls */
+  void UpdateControlStates();
+
+  wxCheckBox* m_enableCheck;  //!< Enable network output
+  wxRadioButton* m_tcpRadio;  //!< Use TCP protocol
+  wxRadioButton* m_udpRadio;  //!< Use UDP protocol
+  wxSpinCtrl* m_portCtrl;     //!< Port number control
+
+  DECLARE_EVENT_TABLE()
+};
+
+#endif  // _VDR_PI_PREFS_NET_H_

--- a/src/vdr_pi_time.cpp
+++ b/src/vdr_pi_time.cpp
@@ -108,7 +108,7 @@ void TimestampParser::ApplyCachedDate(NMEATimeInfo& info) const {
 }
 
 bool TimestampParser::ParseIso8601Timestamp(const wxString& timeStr,
-                                            wxDateTime* timestamp) {
+                                            wxDateTime* timestamp) const {
   // Expected format: YYYY-MM-DDThh:mm:ss.sssZ
 
   // Parse the main date/time part using ISO format
@@ -235,10 +235,11 @@ void TimestampParser::Reset() {
   m_useOnlyPrimarySource = false;
 }
 
-wxString TimestampParser::ParseCSVLineTimestamp(const wxString& line,
-                                                unsigned int timestamp_idx,
-                                                unsigned int message_idx,
-                                                wxDateTime* timestamp) {
+bool TimestampParser::ParseCSVLineTimestamp(const wxString& line,
+                                            unsigned int timestamp_idx,
+                                            unsigned int message_idx,
+                                            wxString* message,
+                                            wxDateTime* timestamp) {
   wxArrayString fields;
   wxString currentField;
   bool inQuotes = false;
@@ -271,16 +272,17 @@ wxString TimestampParser::ParseCSVLineTimestamp(const wxString& line,
   if (timestamp && timestamp_idx != static_cast<unsigned int>(-1) &&
       timestamp_idx < fields.GetCount()) {
     if (!ParseIso8601Timestamp(fields[timestamp_idx], timestamp)) {
-      return wxEmptyString;
+      return false;
     }
   }
 
   // Get message field
   if (message_idx == static_cast<unsigned int>(-1) ||
       message_idx >= fields.GetCount()) {
-    return wxEmptyString;
+    return false;
   }
 
   // No need to unescape quotes here as we handled them during parsing
-  return fields[message_idx];
+  *message = fields[message_idx];
+  return true;
 }

--- a/src/vdr_pi_time.h
+++ b/src/vdr_pi_time.h
@@ -84,7 +84,8 @@ public:
    * @param timestamp Output timestamp in UTC.
    * @return True if the timestamp was successfully parsed.
    */
-  bool ParseIso8601Timestamp(const wxString& timeStr, wxDateTime* timestamp);
+  bool ParseIso8601Timestamp(const wxString& timeStr,
+                             wxDateTime* timestamp) const;
 
   // Reset the cached date state
   void Reset();
@@ -106,13 +107,13 @@ public:
    * @param line CSV line to parse.
    * @param timestamp_idx Index of the timestamp field.
    * @param message_idx Index of the message field.
+   * @param message Output message field.
    * @param timestamp Output timestamp.
-   * @return The message field.
+   * @return True if the timestamp was successfully parsed.
    */
-  wxString ParseCSVLineTimestamp(const wxString& line,
-                                 unsigned int timestamp_idx,
-                                 unsigned int message_idx,
-                                 wxDateTime* timestamp);
+  bool ParseCSVLineTimestamp(const wxString& line, unsigned int timestamp_idx,
+                             unsigned int message_idx, wxString* message,
+                             wxDateTime* timestamp);
 
 private:
   // Cache the last valid date seen from NMEA sentences (RMC, ZDA...)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ endif ()
 
 # Find required packages
 find_package(GTest REQUIRED)
-find_package(wxWidgets COMPONENTS core base REQUIRED)
+find_package(wxWidgets COMPONENTS core base net REQUIRED)
 
 set(SRC
     time_tests.cpp
@@ -29,6 +29,9 @@ set(SRC
     ${CMAKE_SOURCE_DIR}/src/vdr_pi_time.cpp
     ${CMAKE_SOURCE_DIR}/src/vdr_pi.cpp
     ${CMAKE_SOURCE_DIR}/src/vdr_pi_prefs.cpp
+    ${CMAKE_SOURCE_DIR}/src/vdr_pi_prefs_net.cpp
+    ${CMAKE_SOURCE_DIR}/src/vdr_pi_control.cpp
+    ${CMAKE_SOURCE_DIR}/src/vdr_network.cpp
     ${CMAKE_SOURCE_DIR}/src/icons.cpp
 )
 

--- a/test/time_tests.cpp
+++ b/test/time_tests.cpp
@@ -288,11 +288,12 @@ TEST_F(VDRTimeTest, CSVParsingISO8601) {
   wxDateTime timestamp;
   wxString msg =
       "$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A";
-
-  EXPECT_EQ(parser.ParseCSVLineTimestamp(
-                wxString::Format("2024-01-30T12:34:56.123Z,\"%s\"", msg), 0, 1,
-                &timestamp),
-            msg);
+  wxString nmea;
+  bool success = parser.ParseCSVLineTimestamp(
+      wxString::Format("2024-01-30T12:34:56.123Z,\"%s\"", msg), 0, 1, &nmea,
+      &timestamp);
+  EXPECT_TRUE(success);
+  EXPECT_EQ(nmea, msg);
   EXPECT_EQ(timestamp.GetYear(), 2024);
   EXPECT_EQ(timestamp.GetMonth(), wxDateTime::Jan);
   EXPECT_EQ(timestamp.GetDay(), 30);
@@ -301,10 +302,11 @@ TEST_F(VDRTimeTest, CSVParsingISO8601) {
   EXPECT_EQ(timestamp.GetSecond(), 56);
   EXPECT_EQ(timestamp.GetMillisecond(), 123);
 
-  EXPECT_EQ(parser.ParseCSVLineTimestamp(
-                wxString::Format("2024-01-30T12:34:56Z,\"%s\"", msg), 0, 1,
-                &timestamp),
-            msg);
+  success = parser.ParseCSVLineTimestamp(
+      wxString::Format("2024-01-30T12:34:56Z,\"%s\"", msg), 0, 1, &nmea,
+      &timestamp);
+  EXPECT_TRUE(success);
+  EXPECT_EQ(nmea, msg);
   EXPECT_EQ(timestamp.GetYear(), 2024);
   EXPECT_EQ(timestamp.GetMonth(), wxDateTime::Jan);
   EXPECT_EQ(timestamp.GetDay(), 30);


### PR DESCRIPTION
This PR enhances the VDR plugin to support network replay of recorded data and replay of NMEA data over the network.

# Features

1. Network replay configurable as TCP or UDP on `localhost` and configurable network port
2. Independent network settings for each protocol (NMEA 0183, NMEA 2000)
3. In preferences, create two tabs, one for recording preferences and the other for replay preferences.
4. Foundation for future SignalK network replay support

# Other improvements

1. In the control panel, add status labels for file (e.g. load errors), network (e.g. failure to start network server) and playback (playing, pause, stopped...).
2. Improved detection of CSV file.
3. Determine how many good/bad sentences there are in a VDR file. If there are no valid NMEA/AIS sentences, a status message indicates the format is bad. 
4. When reaching end of file, set slider to end position.
5. Fix issue when replaying some CSV files, the replay was jumping very quickly to the end of the file.

Example when file is invalid:

<img width="294" alt="image" src="https://github.com/user-attachments/assets/54c7e9e9-45a1-465b-8a2d-ebf4cfa345ea" />


# Usage

1. Record data using VDR as usual
7. In VDR Replay settings:
   1.  Select whether NMEA0183 should be replayed over the internal API or network.
   2. Enable network output for desired protocols
   8. Configure network settings (TCP/UDP, port)
3. For playback over network:
   1. Create a matching network connection in OpenCPN. Manual configuration of the network connection is required.
   3. Start VDR playback.

**Note**: there is no translation from one protocol to the other (although this could be added in the future).
1. To replay NMEA 0183, the VDR file must contain NMEA 0183 data.
2. To replay NMEA 2000, the VDR file must contain NMEA 2000 data.

<img width="451" alt="image" src="https://github.com/user-attachments/assets/4f347533-9001-4e8d-b319-035d633fca0e" />

 
# Technical details

1. A network server is created on-demand during playback
9. All network communication is local (localhost only)
10. NMEA 2000 are recorded in CSV format.
11. NMEA 2000 messages are replayed in their original recorded format:
   1. SeaSmart ($PCDIN)
   2. Actisense ASCII and binary formats
   7. MiniPlex ($MXPGN)
   12. YD RAW format

# TODO

- [x] Add network settings to `vdr_pi_prefs.h`: Network protocol (TCP/UDP) and Port number (default 10110 standard NMEA port)
- [x] For NMEA0183, add setting to specify if data should be replayed internally (`PushNMEABuffer`) or over the network.
- [x] Save preferences to configuration file.
- [x] In `StartPlayback()`, initialize network servers if needed, i.e. if user has enabled network replay.
- [x] In `StopPlayback()`, shutdown the network servers.
- [x] In `DeInit()`, cleanup the network servers.
- [x] `Notify()` implementation to support replaying NMEA 2000 data over the network.
- [x] `Notify()` implementation to support replaying NMEA 0183 data over the network (in addition to the existing `PushNMEABuffer()`)

# Tests

- [x] Test CSV file with NMEA 0183 data - Internal API
- [x] Test CSV file with NMEA 0183 data - UDP socket
- [ ] Test CSV file with NMEA 0183 data - TCP socket
- [x] Test raw NMEA 0183 data - Internal API
- [x] Test raw NMEA 0183 data - UDP socket
- [ ] Test raw NMEA 0183 data - TCP socket
- [ ] Test CSV file with NMEA 2000 data - UDP socket
- [ ] Test CSV file with NMEA 2000 data - TCP socket

# Known Limitations

1. TCP is a bit problematic because OpenCPN core attempts to create a connection to the server, and there does not seem to be retries. On the other side (VDR plugin), the TCP server isn't started until the VDR plugin starts AND the user clicks play.
2. I have not fully implemented replay of NMEA 2000 data over the network. I need to get a real recording containing NMEA 2000 data, either from someone else, or by reconfiguring my YD device to capture NMEA 2000 data.

